### PR TITLE
feat: add PermissionRequest hook and --settings CLI flag for Looper integration

### DIFF
--- a/codex-rs/app-server-protocol/src/protocol/v2.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2.rs
@@ -372,7 +372,7 @@ v2_enum_from_core!(
 
 v2_enum_from_core!(
     pub enum HookEventName from CoreHookEventName {
-        PreToolUse, PostToolUse, SessionStart, UserPromptSubmit, Stop
+        PreToolUse, PostToolUse, SessionStart, UserPromptSubmit, Stop, PermissionRequest
     }
 );
 

--- a/codex-rs/cli/src/main.rs
+++ b/codex-rs/cli/src/main.rs
@@ -81,6 +81,12 @@ struct MultitoolCli {
     #[clap(flatten)]
     interactive: TuiCli,
 
+    /// Path to a JSON settings file containing additional hook definitions.
+    /// Hooks are merged additively with existing config. Used by external
+    /// supervisors (e.g. Looper) to inject per-agent hooks.
+    #[arg(long = "settings", value_name = "FILE", global = true)]
+    settings_file: Option<PathBuf>,
+
     #[clap(subcommand)]
     subcommand: Option<Subcommand>,
 }
@@ -605,12 +611,15 @@ async fn cli_main(arg0_paths: Arg0DispatchPaths) -> anyhow::Result<()> {
         feature_toggles,
         remote,
         mut interactive,
+        settings_file,
         subcommand,
     } = MultitoolCli::parse();
 
     // Fold --enable/--disable into config overrides so they flow to all subcommands.
     let toggle_overrides = feature_toggles.to_overrides()?;
     root_config_overrides.raw_overrides.extend(toggle_overrides);
+    // Thread --settings through to all subcommands via CliConfigOverrides.
+    root_config_overrides.settings_file = settings_file;
     let root_remote = remote.remote;
     let root_remote_auth_token_env = remote.remote_auth_token_env;
 
@@ -1141,6 +1150,9 @@ fn prepend_config_flags(
     subcommand_config_overrides
         .raw_overrides
         .splice(0..0, cli_config_overrides.raw_overrides);
+    if subcommand_config_overrides.settings_file.is_none() {
+        subcommand_config_overrides.settings_file = cli_config_overrides.settings_file;
+    }
 }
 
 fn reject_remote_mode_for_subcommand(

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -1827,6 +1827,7 @@ impl Session {
             config_layer_stack: Some(config.config_layer_stack.clone()),
             shell_program: Some(hook_shell_program),
             shell_args: hook_shell_argv,
+            settings_file: config.settings_file.clone(),
         });
         for warning in hooks.startup_warnings() {
             post_session_configured_events.push(Event {
@@ -2938,6 +2939,20 @@ impl Session {
                 additional_permissions.as_ref(),
             )
         });
+        // Fire PermissionRequest hook so external supervisors (e.g. Looper)
+        // can detect that the agent is blocked waiting for human approval.
+        let perm_request = codex_hooks::PermissionRequestRequest {
+            session_id: self.conversation_id,
+            turn_id: turn_context.sub_id.clone(),
+            cwd: turn_context.cwd.to_path_buf(),
+            transcript_path: self.hook_transcript_path().await,
+            model: turn_context.model_info.slug.clone(),
+            permission_mode: crate::hook_runtime::hook_permission_mode(turn_context),
+            tool_name: "Bash".to_string(),
+            tool_input: command.join(" "),
+        };
+        let _perm_outcome = self.hooks().run_permission_request(perm_request).await;
+
         let event = EventMsg::ExecApprovalRequest(ExecApprovalRequestEvent {
             call_id,
             approval_id,

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -575,6 +575,10 @@ pub struct Config {
     /// Configured discoverable tools for tool suggestions.
     pub tool_suggest: ToolSuggestConfig,
 
+    /// Optional path to a settings file containing additional hook definitions.
+    /// Used by external supervisors (e.g. Looper) to inject per-session hooks.
+    pub settings_file: Option<PathBuf>,
+
     /// OTEL configuration (exporter type, endpoint, headers, etc.).
     pub otel: crate::config::types::OtelConfig,
 }
@@ -1810,6 +1814,10 @@ pub struct ConfigOverrides {
     pub ephemeral: Option<bool>,
     /// Additional directories that should be treated as writable roots for this session.
     pub additional_writable_roots: Vec<PathBuf>,
+    /// Optional path to a settings file containing additional hook definitions,
+    /// merged additively with existing config. Used by external supervisors
+    /// (e.g. Looper) to inject per-agent hooks.
+    pub settings_file: Option<PathBuf>,
 }
 
 fn validate_reserved_model_provider_ids(
@@ -2008,6 +2016,7 @@ impl Config {
             tools_web_search_request: override_tools_web_search_request,
             ephemeral,
             additional_writable_roots,
+            settings_file,
         } = overrides;
 
         let active_profile_name = config_profile_key
@@ -2699,6 +2708,7 @@ impl Config {
             tui_status_line: cfg.tui.as_ref().and_then(|t| t.status_line.clone()),
             tui_terminal_title: cfg.tui.as_ref().and_then(|t| t.terminal_title.clone()),
             tui_theme: cfg.tui.as_ref().and_then(|t| t.theme.clone()),
+            settings_file,
             otel: {
                 let t: OtelConfigToml = cfg.otel.unwrap_or_default();
                 let log_user_prompt = t.log_user_prompt.unwrap_or(false);

--- a/codex-rs/core/src/hook_runtime.rs
+++ b/codex-rs/core/src/hook_runtime.rs
@@ -1,6 +1,7 @@
 use std::future::Future;
 use std::sync::Arc;
 
+use codex_hooks::PermissionRequestRequest;
 use codex_hooks::PostToolUseOutcome;
 use codex_hooks::PostToolUseRequest;
 use codex_hooks::PreToolUseOutcome;
@@ -171,6 +172,30 @@ pub(crate) async fn run_post_tool_use_hooks(
     outcome
 }
 
+#[allow(dead_code)]
+pub(crate) async fn run_permission_request_hooks(
+    sess: &Arc<Session>,
+    turn_context: &Arc<TurnContext>,
+    tool_name: String,
+    tool_input: String,
+) {
+    let request = PermissionRequestRequest {
+        session_id: sess.conversation_id,
+        turn_id: turn_context.sub_id.clone(),
+        cwd: turn_context.cwd.to_path_buf(),
+        transcript_path: sess.hook_transcript_path().await,
+        model: turn_context.model_info.slug.clone(),
+        permission_mode: hook_permission_mode(turn_context),
+        tool_name,
+        tool_input,
+    };
+    let preview_runs = sess.hooks().preview_permission_request(&request);
+    emit_hook_started_events(sess, turn_context, preview_runs).await;
+
+    let outcome = sess.hooks().run_permission_request(request).await;
+    emit_hook_completed_events(sess, turn_context, outcome.hook_events).await;
+}
+
 pub(crate) async fn run_user_prompt_submit_hooks(
     sess: &Arc<Session>,
     turn_context: &Arc<TurnContext>,
@@ -326,7 +351,7 @@ async fn emit_hook_completed_events(
     }
 }
 
-fn hook_permission_mode(turn_context: &TurnContext) -> String {
+pub(crate) fn hook_permission_mode(turn_context: &TurnContext) -> String {
     match turn_context.approval_policy.value() {
         AskForApproval::Never => "bypassPermissions",
         AskForApproval::UnlessTrusted

--- a/codex-rs/exec/src/lib.rs
+++ b/codex-rs/exec/src/lib.rs
@@ -342,6 +342,7 @@ pub async fn run_main(cli: Cli, arg0_paths: Arg0DispatchPaths) -> anyhow::Result
         tools_web_search_request: None,
         ephemeral: ephemeral.then_some(true),
         additional_writable_roots: add_dir,
+        settings_file: config_overrides.settings_file.clone(),
     };
 
     let config = ConfigBuilder::default()

--- a/codex-rs/exec/src/main.rs
+++ b/codex-rs/exec/src/main.rs
@@ -34,6 +34,9 @@ fn main() -> anyhow::Result<()> {
             .config_overrides
             .raw_overrides
             .splice(0..0, top_cli.config_overrides.raw_overrides);
+        if inner.config_overrides.settings_file.is_none() {
+            inner.config_overrides.settings_file = top_cli.config_overrides.settings_file;
+        }
 
         run_main(inner, arg0_paths).await?;
         Ok(())

--- a/codex-rs/hooks/schema/generated/permission-request.command.input.schema.json
+++ b/codex-rs/hooks/schema/generated/permission-request.command.input.schema.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "definitions": {
+    "NullableString": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "PermissionRequestToolInput": {
+      "additionalProperties": false,
+      "properties": {
+        "command": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "command"
+      ],
+      "type": "object"
+    }
+  },
+  "properties": {
+    "cwd": {
+      "type": "string"
+    },
+    "hook_event_name": {
+      "const": "PermissionRequest",
+      "type": "string"
+    },
+    "model": {
+      "type": "string"
+    },
+    "permission_mode": {
+      "enum": [
+        "default",
+        "acceptEdits",
+        "plan",
+        "dontAsk",
+        "bypassPermissions"
+      ],
+      "type": "string"
+    },
+    "session_id": {
+      "type": "string"
+    },
+    "tool_input": {
+      "$ref": "#/definitions/PermissionRequestToolInput"
+    },
+    "tool_name": {
+      "type": "string"
+    },
+    "transcript_path": {
+      "$ref": "#/definitions/NullableString"
+    },
+    "turn_id": {
+      "description": "Codex extension: expose the active turn id to internal turn-scoped hooks.",
+      "type": "string"
+    }
+  },
+  "required": [
+    "cwd",
+    "hook_event_name",
+    "model",
+    "permission_mode",
+    "session_id",
+    "tool_input",
+    "tool_name",
+    "transcript_path",
+    "turn_id"
+  ],
+  "title": "permission-request.command.input",
+  "type": "object"
+}

--- a/codex-rs/hooks/schema/generated/post-tool-use.command.output.schema.json
+++ b/codex-rs/hooks/schema/generated/post-tool-use.command.output.schema.json
@@ -14,7 +14,8 @@
         "PostToolUse",
         "SessionStart",
         "UserPromptSubmit",
-        "Stop"
+        "Stop",
+        "PermissionRequest"
       ],
       "type": "string"
     },

--- a/codex-rs/hooks/schema/generated/pre-tool-use.command.output.schema.json
+++ b/codex-rs/hooks/schema/generated/pre-tool-use.command.output.schema.json
@@ -8,7 +8,8 @@
         "PostToolUse",
         "SessionStart",
         "UserPromptSubmit",
-        "Stop"
+        "Stop",
+        "PermissionRequest"
       ],
       "type": "string"
     },

--- a/codex-rs/hooks/schema/generated/session-start.command.output.schema.json
+++ b/codex-rs/hooks/schema/generated/session-start.command.output.schema.json
@@ -8,7 +8,8 @@
         "PostToolUse",
         "SessionStart",
         "UserPromptSubmit",
-        "Stop"
+        "Stop",
+        "PermissionRequest"
       ],
       "type": "string"
     },

--- a/codex-rs/hooks/schema/generated/user-prompt-submit.command.output.schema.json
+++ b/codex-rs/hooks/schema/generated/user-prompt-submit.command.output.schema.json
@@ -14,7 +14,8 @@
         "PostToolUse",
         "SessionStart",
         "UserPromptSubmit",
-        "Stop"
+        "Stop",
+        "PermissionRequest"
       ],
       "type": "string"
     },

--- a/codex-rs/hooks/src/engine/config.rs
+++ b/codex-rs/hooks/src/engine/config.rs
@@ -18,6 +18,8 @@ pub(crate) struct HookEvents {
     pub user_prompt_submit: Vec<MatcherGroup>,
     #[serde(rename = "Stop", default)]
     pub stop: Vec<MatcherGroup>,
+    #[serde(rename = "PermissionRequest", default)]
+    pub permission_request: Vec<MatcherGroup>,
 }
 
 #[derive(Debug, Default, Deserialize)]

--- a/codex-rs/hooks/src/engine/discovery.rs
+++ b/codex-rs/hooks/src/engine/discovery.rs
@@ -16,17 +16,26 @@ pub(crate) struct DiscoveryResult {
     pub warnings: Vec<String>,
 }
 
-pub(crate) fn discover_handlers(config_layer_stack: Option<&ConfigLayerStack>) -> DiscoveryResult {
-    let Some(config_layer_stack) = config_layer_stack else {
-        return DiscoveryResult {
-            handlers: Vec::new(),
-            warnings: Vec::new(),
-        };
-    };
-
+pub(crate) fn discover_handlers(
+    config_layer_stack: Option<&ConfigLayerStack>,
+    settings_file: Option<&Path>,
+) -> DiscoveryResult {
     let mut handlers = Vec::new();
     let mut warnings = Vec::new();
     let mut display_order = 0_i64;
+
+    // Load hooks from the config layer stack (e.g. ~/.codex/hooks.json, ./.codex/hooks.json).
+    let Some(config_layer_stack) = config_layer_stack else {
+        if let Some(settings_file) = settings_file {
+            load_hooks_from_file(
+                settings_file,
+                &mut handlers,
+                &mut warnings,
+                &mut display_order,
+            );
+        }
+        return DiscoveryResult { handlers, warnings };
+    };
 
     for layer in config_layer_stack.get_layers(
         ConfigLayerStackOrdering::LowestPrecedenceFirst,
@@ -77,6 +86,7 @@ pub(crate) fn discover_handlers(config_layer_stack: Option<&ConfigLayerStack>) -
             session_start,
             user_prompt_submit,
             stop,
+            permission_request,
         } = parsed.hooks;
 
         for (event_name, groups) in [
@@ -97,6 +107,10 @@ pub(crate) fn discover_handlers(config_layer_stack: Option<&ConfigLayerStack>) -
                 user_prompt_submit,
             ),
             (codex_protocol::protocol::HookEventName::Stop, stop),
+            (
+                codex_protocol::protocol::HookEventName::PermissionRequest,
+                permission_request,
+            ),
         ] {
             append_matcher_groups(
                 &mut handlers,
@@ -109,7 +123,97 @@ pub(crate) fn discover_handlers(config_layer_stack: Option<&ConfigLayerStack>) -
         }
     }
 
+    // Load hooks from the per-session settings file (e.g. --settings <path>),
+    // merged additively after all config layer hooks.
+    if let Some(settings_file) = settings_file {
+        load_hooks_from_file(
+            settings_file,
+            &mut handlers,
+            &mut warnings,
+            &mut display_order,
+        );
+    }
+
     DiscoveryResult { handlers, warnings }
+}
+
+fn load_hooks_from_file(
+    source_path: &Path,
+    handlers: &mut Vec<ConfiguredHandler>,
+    warnings: &mut Vec<String>,
+    display_order: &mut i64,
+) {
+    if !source_path.is_file() {
+        warnings.push(format!(
+            "settings file not found: {}",
+            source_path.display()
+        ));
+        return;
+    }
+
+    let contents = match fs::read_to_string(source_path) {
+        Ok(contents) => contents,
+        Err(err) => {
+            warnings.push(format!(
+                "failed to read settings file {}: {err}",
+                source_path.display()
+            ));
+            return;
+        }
+    };
+
+    let parsed: HooksFile = match serde_json::from_str(&contents) {
+        Ok(parsed) => parsed,
+        Err(err) => {
+            warnings.push(format!(
+                "failed to parse settings file {}: {err}",
+                source_path.display()
+            ));
+            return;
+        }
+    };
+
+    let super::config::HookEvents {
+        pre_tool_use,
+        post_tool_use,
+        session_start,
+        user_prompt_submit,
+        stop,
+        permission_request,
+    } = parsed.hooks;
+
+    for (event_name, groups) in [
+        (
+            codex_protocol::protocol::HookEventName::PreToolUse,
+            pre_tool_use,
+        ),
+        (
+            codex_protocol::protocol::HookEventName::PostToolUse,
+            post_tool_use,
+        ),
+        (
+            codex_protocol::protocol::HookEventName::SessionStart,
+            session_start,
+        ),
+        (
+            codex_protocol::protocol::HookEventName::UserPromptSubmit,
+            user_prompt_submit,
+        ),
+        (codex_protocol::protocol::HookEventName::Stop, stop),
+        (
+            codex_protocol::protocol::HookEventName::PermissionRequest,
+            permission_request,
+        ),
+    ] {
+        append_matcher_groups(
+            handlers,
+            warnings,
+            display_order,
+            source_path,
+            event_name,
+            groups,
+        );
+    }
 }
 
 fn append_group_handlers(

--- a/codex-rs/hooks/src/engine/dispatcher.rs
+++ b/codex-rs/hooks/src/engine/dispatcher.rs
@@ -33,7 +33,8 @@ pub(crate) fn select_handlers(
         .filter(|handler| match event_name {
             HookEventName::PreToolUse
             | HookEventName::PostToolUse
-            | HookEventName::SessionStart => {
+            | HookEventName::SessionStart
+            | HookEventName::PermissionRequest => {
                 matches_matcher(handler.matcher.as_deref(), matcher_input)
             }
             HookEventName::UserPromptSubmit | HookEventName::Stop => true,
@@ -111,7 +112,8 @@ fn scope_for_event(event_name: HookEventName) -> HookScope {
         HookEventName::PreToolUse
         | HookEventName::PostToolUse
         | HookEventName::UserPromptSubmit
-        | HookEventName::Stop => HookScope::Turn,
+        | HookEventName::Stop
+        | HookEventName::PermissionRequest => HookScope::Turn,
     }
 }
 

--- a/codex-rs/hooks/src/engine/mod.rs
+++ b/codex-rs/hooks/src/engine/mod.rs
@@ -16,6 +16,8 @@ use crate::events::pre_tool_use::PreToolUseOutcome;
 use crate::events::pre_tool_use::PreToolUseRequest;
 use crate::events::session_start::SessionStartOutcome;
 use crate::events::session_start::SessionStartRequest;
+use crate::events::permission_request::PermissionRequestOutcome;
+use crate::events::permission_request::PermissionRequestRequest;
 use crate::events::stop::StopOutcome;
 use crate::events::stop::StopRequest;
 use crate::events::user_prompt_submit::UserPromptSubmitOutcome;
@@ -55,6 +57,7 @@ impl ConfiguredHandler {
             codex_protocol::protocol::HookEventName::SessionStart => "session-start",
             codex_protocol::protocol::HookEventName::UserPromptSubmit => "user-prompt-submit",
             codex_protocol::protocol::HookEventName::Stop => "stop",
+            codex_protocol::protocol::HookEventName::PermissionRequest => "permission-request",
         }
     }
 }
@@ -71,6 +74,7 @@ impl ClaudeHooksEngine {
         enabled: bool,
         config_layer_stack: Option<&ConfigLayerStack>,
         shell: CommandShell,
+        settings_file: Option<std::path::PathBuf>,
     ) -> Self {
         if !enabled {
             return Self {
@@ -92,7 +96,7 @@ impl ClaudeHooksEngine {
         }
 
         let _ = schema_loader::generated_hook_schemas();
-        let discovered = discovery::discover_handlers(config_layer_stack);
+        let discovered = discovery::discover_handlers(config_layer_stack, settings_file.as_deref());
         Self {
             handlers: discovered.handlers,
             warnings: discovered.warnings,
@@ -161,5 +165,19 @@ impl ClaudeHooksEngine {
 
     pub(crate) async fn run_stop(&self, request: StopRequest) -> StopOutcome {
         crate::events::stop::run(&self.handlers, &self.shell, request).await
+    }
+
+    pub(crate) fn preview_permission_request(
+        &self,
+        request: &PermissionRequestRequest,
+    ) -> Vec<HookRunSummary> {
+        crate::events::permission_request::preview(&self.handlers, request)
+    }
+
+    pub(crate) async fn run_permission_request(
+        &self,
+        request: PermissionRequestRequest,
+    ) -> PermissionRequestOutcome {
+        crate::events::permission_request::run(&self.handlers, &self.shell, request).await
     }
 }

--- a/codex-rs/hooks/src/engine/schema_loader.rs
+++ b/codex-rs/hooks/src/engine/schema_loader.rs
@@ -14,6 +14,7 @@ pub(crate) struct GeneratedHookSchemas {
     pub user_prompt_submit_command_output: Value,
     pub stop_command_input: Value,
     pub stop_command_output: Value,
+    pub permission_request_command_input: Value,
 }
 
 pub(crate) fn generated_hook_schemas() -> &'static GeneratedHookSchemas {
@@ -59,6 +60,10 @@ pub(crate) fn generated_hook_schemas() -> &'static GeneratedHookSchemas {
             "stop.command.output",
             include_str!("../../schema/generated/stop.command.output.schema.json"),
         ),
+        permission_request_command_input: parse_json_schema(
+            "permission-request.command.input",
+            include_str!("../../schema/generated/permission-request.command.input.schema.json"),
+        ),
     })
 }
 
@@ -86,5 +91,9 @@ mod tests {
         assert_eq!(schemas.user_prompt_submit_command_output["type"], "object");
         assert_eq!(schemas.stop_command_input["type"], "object");
         assert_eq!(schemas.stop_command_output["type"], "object");
+        assert_eq!(
+            schemas.permission_request_command_input["type"],
+            "object"
+        );
     }
 }

--- a/codex-rs/hooks/src/events/common.rs
+++ b/codex-rs/hooks/src/events/common.rs
@@ -74,9 +74,10 @@ pub(crate) fn matcher_pattern_for_event(
     matcher: Option<&str>,
 ) -> Option<&str> {
     match event_name {
-        HookEventName::PreToolUse | HookEventName::PostToolUse | HookEventName::SessionStart => {
-            matcher
-        }
+        HookEventName::PreToolUse
+        | HookEventName::PostToolUse
+        | HookEventName::SessionStart
+        | HookEventName::PermissionRequest => matcher,
         HookEventName::UserPromptSubmit | HookEventName::Stop => None,
     }
 }

--- a/codex-rs/hooks/src/events/mod.rs
+++ b/codex-rs/hooks/src/events/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod common;
+pub mod permission_request;
 pub mod post_tool_use;
 pub mod pre_tool_use;
 pub mod session_start;

--- a/codex-rs/hooks/src/events/permission_request.rs
+++ b/codex-rs/hooks/src/events/permission_request.rs
@@ -1,0 +1,215 @@
+use std::path::PathBuf;
+
+use codex_protocol::ThreadId;
+use codex_protocol::protocol::HookCompletedEvent;
+use codex_protocol::protocol::HookEventName;
+use codex_protocol::protocol::HookOutputEntry;
+use codex_protocol::protocol::HookOutputEntryKind;
+use codex_protocol::protocol::HookRunStatus;
+use codex_protocol::protocol::HookRunSummary;
+
+use super::common;
+use crate::engine::CommandShell;
+use crate::engine::ConfiguredHandler;
+use crate::engine::command_runner::CommandRunResult;
+use crate::engine::dispatcher;
+use crate::schema::PermissionRequestCommandInput;
+use crate::schema::PermissionRequestToolInput;
+
+#[derive(Debug, Clone)]
+pub struct PermissionRequestRequest {
+    pub session_id: ThreadId,
+    pub turn_id: String,
+    pub cwd: PathBuf,
+    pub transcript_path: Option<PathBuf>,
+    pub model: String,
+    pub permission_mode: String,
+    pub tool_name: String,
+    pub tool_input: String,
+}
+
+#[derive(Debug)]
+pub struct PermissionRequestOutcome {
+    pub hook_events: Vec<HookCompletedEvent>,
+}
+
+#[derive(Debug, Default)]
+struct PermissionRequestHandlerData;
+
+pub(crate) fn preview(
+    handlers: &[ConfiguredHandler],
+    request: &PermissionRequestRequest,
+) -> Vec<HookRunSummary> {
+    dispatcher::select_handlers(
+        handlers,
+        HookEventName::PermissionRequest,
+        Some(&request.tool_name),
+    )
+    .into_iter()
+    .map(|handler| dispatcher::running_summary(&handler))
+    .collect()
+}
+
+pub(crate) async fn run(
+    handlers: &[ConfiguredHandler],
+    shell: &CommandShell,
+    request: PermissionRequestRequest,
+) -> PermissionRequestOutcome {
+    let matched = dispatcher::select_handlers(
+        handlers,
+        HookEventName::PermissionRequest,
+        Some(&request.tool_name),
+    );
+    if matched.is_empty() {
+        return PermissionRequestOutcome {
+            hook_events: Vec::new(),
+        };
+    }
+
+    let input_json = match serde_json::to_string(&PermissionRequestCommandInput {
+        session_id: request.session_id.to_string(),
+        turn_id: request.turn_id.clone(),
+        transcript_path: crate::schema::NullableString::from_path(request.transcript_path.clone()),
+        cwd: request.cwd.display().to_string(),
+        hook_event_name: "PermissionRequest".to_string(),
+        model: request.model.clone(),
+        permission_mode: request.permission_mode.clone(),
+        tool_name: request.tool_name.clone(),
+        tool_input: PermissionRequestToolInput {
+            command: request.tool_input.clone(),
+        },
+    }) {
+        Ok(input_json) => input_json,
+        Err(error) => {
+            return PermissionRequestOutcome {
+                hook_events: common::serialization_failure_hook_events(
+                    matched,
+                    Some(request.turn_id),
+                    format!("failed to serialize permission request hook input: {error}"),
+                ),
+            };
+        }
+    };
+
+    let results = dispatcher::execute_handlers(
+        shell,
+        matched,
+        input_json,
+        request.cwd.as_path(),
+        Some(request.turn_id),
+        parse_completed,
+    )
+    .await;
+
+    PermissionRequestOutcome {
+        hook_events: results.into_iter().map(|result| result.completed).collect(),
+    }
+}
+
+fn parse_completed(
+    handler: &ConfiguredHandler,
+    run_result: CommandRunResult,
+    turn_id: Option<String>,
+) -> dispatcher::ParsedHandler<PermissionRequestHandlerData> {
+    let mut entries = Vec::new();
+    let mut status = HookRunStatus::Completed;
+
+    match run_result.error.as_deref() {
+        Some(error) => {
+            status = HookRunStatus::Failed;
+            entries.push(HookOutputEntry {
+                kind: HookOutputEntryKind::Error,
+                text: error.to_string(),
+            });
+        }
+        None => match run_result.exit_code {
+            Some(0) => {
+                // PermissionRequest is a notification-only hook.
+                // We do not parse stdout — any output is silently ignored.
+            }
+            Some(exit_code) => {
+                status = HookRunStatus::Failed;
+                entries.push(HookOutputEntry {
+                    kind: HookOutputEntryKind::Error,
+                    text: format!("hook exited with code {exit_code}"),
+                });
+            }
+            None => {
+                status = HookRunStatus::Failed;
+                entries.push(HookOutputEntry {
+                    kind: HookOutputEntryKind::Error,
+                    text: "hook exited without a status code".to_string(),
+                });
+            }
+        },
+    }
+
+    dispatcher::ParsedHandler {
+        completed: HookCompletedEvent {
+            turn_id,
+            run: dispatcher::completed_summary(handler, &run_result, status, entries),
+        },
+        data: PermissionRequestHandlerData,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use codex_protocol::protocol::HookEventName;
+    use codex_protocol::protocol::HookRunStatus;
+    use pretty_assertions::assert_eq;
+
+    use super::parse_completed;
+    use crate::engine::ConfiguredHandler;
+    use crate::engine::command_runner::CommandRunResult;
+
+    #[test]
+    fn successful_hook_completes() {
+        let parsed = parse_completed(
+            &handler(),
+            run_result(Some(0), "", ""),
+            Some("turn-1".to_string()),
+        );
+
+        assert_eq!(parsed.completed.run.status, HookRunStatus::Completed);
+        assert_eq!(parsed.completed.run.entries, vec![]);
+    }
+
+    #[test]
+    fn nonzero_exit_code_fails() {
+        let parsed = parse_completed(
+            &handler(),
+            run_result(Some(1), "", "some error"),
+            Some("turn-1".to_string()),
+        );
+
+        assert_eq!(parsed.completed.run.status, HookRunStatus::Failed);
+        assert_eq!(parsed.completed.run.entries.len(), 1);
+    }
+
+    fn handler() -> ConfiguredHandler {
+        ConfiguredHandler {
+            event_name: HookEventName::PermissionRequest,
+            matcher: None,
+            command: "echo hook".to_string(),
+            timeout_sec: 5,
+            status_message: None,
+            source_path: PathBuf::from("/tmp/hooks.json"),
+            display_order: 0,
+        }
+    }
+
+    fn run_result(exit_code: Option<i32>, stdout: &str, stderr: &str) -> CommandRunResult {
+        CommandRunResult {
+            started_at: 1,
+            completed_at: 2,
+            duration_ms: 1,
+            exit_code,
+            stdout: stdout.to_string(),
+            stderr: stderr.to_string(),
+            error: None,
+        }
+    }
+}

--- a/codex-rs/hooks/src/lib.rs
+++ b/codex-rs/hooks/src/lib.rs
@@ -5,6 +5,8 @@ mod registry;
 mod schema;
 mod types;
 
+pub use events::permission_request::PermissionRequestOutcome;
+pub use events::permission_request::PermissionRequestRequest;
 pub use events::post_tool_use::PostToolUseOutcome;
 pub use events::post_tool_use::PostToolUseRequest;
 pub use events::pre_tool_use::PreToolUseOutcome;

--- a/codex-rs/hooks/src/registry.rs
+++ b/codex-rs/hooks/src/registry.rs
@@ -3,6 +3,8 @@ use tokio::process::Command;
 
 use crate::engine::ClaudeHooksEngine;
 use crate::engine::CommandShell;
+use crate::events::permission_request::PermissionRequestOutcome;
+use crate::events::permission_request::PermissionRequestRequest;
 use crate::events::post_tool_use::PostToolUseOutcome;
 use crate::events::post_tool_use::PostToolUseRequest;
 use crate::events::pre_tool_use::PreToolUseOutcome;
@@ -25,6 +27,9 @@ pub struct HooksConfig {
     pub config_layer_stack: Option<ConfigLayerStack>,
     pub shell_program: Option<String>,
     pub shell_args: Vec<String>,
+    /// Optional path to a settings file containing additional hook definitions.
+    /// Hooks are merged additively (not replacing existing config).
+    pub settings_file: Option<std::path::PathBuf>,
 }
 
 #[derive(Clone)]
@@ -55,6 +60,7 @@ impl Hooks {
                 program: config.shell_program.unwrap_or_default(),
                 args: config.shell_args,
             },
+            config.settings_file,
         );
         Self {
             after_agent,
@@ -149,6 +155,20 @@ impl Hooks {
 
     pub async fn run_stop(&self, request: StopRequest) -> StopOutcome {
         self.engine.run_stop(request).await
+    }
+
+    pub fn preview_permission_request(
+        &self,
+        request: &PermissionRequestRequest,
+    ) -> Vec<codex_protocol::protocol::HookRunSummary> {
+        self.engine.preview_permission_request(request)
+    }
+
+    pub async fn run_permission_request(
+        &self,
+        request: PermissionRequestRequest,
+    ) -> PermissionRequestOutcome {
+        self.engine.run_permission_request(request).await
     }
 }
 

--- a/codex-rs/hooks/src/schema.rs
+++ b/codex-rs/hooks/src/schema.rs
@@ -23,6 +23,7 @@ const USER_PROMPT_SUBMIT_INPUT_FIXTURE: &str = "user-prompt-submit.command.input
 const USER_PROMPT_SUBMIT_OUTPUT_FIXTURE: &str = "user-prompt-submit.command.output.schema.json";
 const STOP_INPUT_FIXTURE: &str = "stop.command.input.schema.json";
 const STOP_OUTPUT_FIXTURE: &str = "stop.command.output.schema.json";
+const PERMISSION_REQUEST_INPUT_FIXTURE: &str = "permission-request.command.input.schema.json";
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(transparent)]
@@ -77,6 +78,8 @@ pub(crate) enum HookEventNameWire {
     UserPromptSubmit,
     #[serde(rename = "Stop")]
     Stop,
+    #[serde(rename = "PermissionRequest")]
+    PermissionRequest,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -346,6 +349,30 @@ pub(crate) struct StopCommandInput {
     pub last_assistant_message: NullableString,
 }
 
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+#[schemars(rename = "permission-request.command.input")]
+pub(crate) struct PermissionRequestCommandInput {
+    pub session_id: String,
+    /// Codex extension: expose the active turn id to internal turn-scoped hooks.
+    pub turn_id: String,
+    pub transcript_path: NullableString,
+    pub cwd: String,
+    #[schemars(schema_with = "permission_request_hook_event_name_schema")]
+    pub hook_event_name: String,
+    pub model: String,
+    #[schemars(schema_with = "permission_mode_schema")]
+    pub permission_mode: String,
+    pub tool_name: String,
+    pub tool_input: PermissionRequestToolInput,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct PermissionRequestToolInput {
+    pub command: String,
+}
+
 pub fn write_schema_fixtures(schema_root: &Path) -> anyhow::Result<()> {
     let generated_dir = schema_root.join(GENERATED_DIR);
     ensure_empty_dir(&generated_dir)?;
@@ -389,6 +416,10 @@ pub fn write_schema_fixtures(schema_root: &Path) -> anyhow::Result<()> {
     write_schema(
         &generated_dir.join(STOP_OUTPUT_FIXTURE),
         schema_json::<StopCommandOutputWire>()?,
+    )?;
+    write_schema(
+        &generated_dir.join(PERMISSION_REQUEST_INPUT_FIXTURE),
+        schema_json::<PermissionRequestCommandInput>()?,
     )?;
 
     Ok(())
@@ -473,6 +504,10 @@ fn stop_hook_event_name_schema(_gen: &mut SchemaGenerator) -> Schema {
     string_const_schema("Stop")
 }
 
+fn permission_request_hook_event_name_schema(_gen: &mut SchemaGenerator) -> Schema {
+    string_const_schema("PermissionRequest")
+}
+
 fn permission_mode_schema(_gen: &mut SchemaGenerator) -> Schema {
     string_enum_schema(&[
         "default",
@@ -516,10 +551,12 @@ fn default_continue() -> bool {
 
 #[cfg(test)]
 mod tests {
+    use super::PERMISSION_REQUEST_INPUT_FIXTURE;
     use super::POST_TOOL_USE_INPUT_FIXTURE;
     use super::POST_TOOL_USE_OUTPUT_FIXTURE;
     use super::PRE_TOOL_USE_INPUT_FIXTURE;
     use super::PRE_TOOL_USE_OUTPUT_FIXTURE;
+    use super::PermissionRequestCommandInput;
     use super::PostToolUseCommandInput;
     use super::PreToolUseCommandInput;
     use super::SESSION_START_INPUT_FIXTURE;
@@ -568,6 +605,11 @@ mod tests {
             STOP_OUTPUT_FIXTURE => {
                 include_str!("../schema/generated/stop.command.output.schema.json")
             }
+            PERMISSION_REQUEST_INPUT_FIXTURE => {
+                include_str!(
+                    "../schema/generated/permission-request.command.input.schema.json"
+                )
+            }
             _ => panic!("unexpected fixture name: {name}"),
         }
     }
@@ -593,6 +635,7 @@ mod tests {
             USER_PROMPT_SUBMIT_OUTPUT_FIXTURE,
             STOP_INPUT_FIXTURE,
             STOP_OUTPUT_FIXTURE,
+            PERMISSION_REQUEST_INPUT_FIXTURE,
         ] {
             let expected = normalize_newlines(expected_fixture(fixture));
             let actual = std::fs::read_to_string(schema_root.join("generated").join(fixture))
@@ -624,8 +667,19 @@ mod tests {
             &schema_json::<StopCommandInput>().expect("serialize stop input schema"),
         )
         .expect("parse stop input schema");
+        let permission_request: Value = serde_json::from_slice(
+            &schema_json::<PermissionRequestCommandInput>()
+                .expect("serialize permission request input schema"),
+        )
+        .expect("parse permission request input schema");
 
-        for schema in [&pre_tool_use, &post_tool_use, &user_prompt_submit, &stop] {
+        for schema in [
+            &pre_tool_use,
+            &post_tool_use,
+            &user_prompt_submit,
+            &stop,
+            &permission_request,
+        ] {
             assert_eq!(schema["properties"]["turn_id"]["type"], "string");
             assert!(
                 schema["required"]

--- a/codex-rs/protocol/src/protocol.rs
+++ b/codex-rs/protocol/src/protocol.rs
@@ -1425,6 +1425,7 @@ pub enum HookEventName {
     SessionStart,
     UserPromptSubmit,
     Stop,
+    PermissionRequest,
 }
 
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq, JsonSchema, TS)]

--- a/codex-rs/tui/src/app_server_tui_dispatch.rs
+++ b/codex-rs/tui/src/app_server_tui_dispatch.rs
@@ -13,13 +13,17 @@ pub(crate) fn app_server_tui_config_inputs(
         raw_overrides.push("web_search=\"live\"".to_string());
     }
 
-    let cli_kv_overrides = codex_utils_cli::CliConfigOverrides { raw_overrides }
-        .parse_overrides()
-        .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidInput, err))?;
+    let cli_kv_overrides = codex_utils_cli::CliConfigOverrides {
+        raw_overrides,
+        settings_file: cli.config_overrides.settings_file.clone(),
+    }
+    .parse_overrides()
+    .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidInput, err))?;
 
     let config_overrides = ConfigOverrides {
         cwd: cli.cwd.clone(),
         config_profile: cli.config_profile.clone(),
+        settings_file: cli.config_overrides.settings_file.clone(),
         ..Default::default()
     };
 

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -9644,6 +9644,7 @@ fn hook_event_label(event_name: codex_protocol::protocol::HookEventName) -> &'st
         codex_protocol::protocol::HookEventName::SessionStart => "SessionStart",
         codex_protocol::protocol::HookEventName::UserPromptSubmit => "UserPromptSubmit",
         codex_protocol::protocol::HookEventName::Stop => "Stop",
+        codex_protocol::protocol::HookEventName::PermissionRequest => "PermissionRequest",
     }
 }
 

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -297,8 +297,12 @@ pub async fn run_main(
     // When using `--oss`, let the bootstrapper pick the model (defaulting to
     // gpt-oss:20b) and ensure it is present locally. Also, force the built‑in
     let raw_overrides = cli.config_overrides.raw_overrides.clone();
+    let settings_file = cli.config_overrides.settings_file.clone();
     // `oss` model provider.
-    let overrides_cli = codex_utils_cli::CliConfigOverrides { raw_overrides };
+    let overrides_cli = codex_utils_cli::CliConfigOverrides {
+        raw_overrides,
+        settings_file: settings_file.clone(),
+    };
     let cli_kv_overrides = match overrides_cli.parse_overrides() {
         // Parse `-c` overrides from the CLI.
         Ok(v) => v,
@@ -423,6 +427,7 @@ pub async fn run_main(
         main_execve_wrapper_exe: arg0_paths.main_execve_wrapper_exe.clone(),
         show_raw_agent_reasoning: cli.oss.then_some(true),
         additional_writable_roots: additional_dirs,
+        settings_file,
         ..Default::default()
     };
 

--- a/codex-rs/tui_app_server/src/chatwidget.rs
+++ b/codex-rs/tui_app_server/src/chatwidget.rs
@@ -10810,6 +10810,7 @@ fn hook_event_label(event_name: codex_protocol::protocol::HookEventName) -> &'st
         codex_protocol::protocol::HookEventName::SessionStart => "SessionStart",
         codex_protocol::protocol::HookEventName::UserPromptSubmit => "UserPromptSubmit",
         codex_protocol::protocol::HookEventName::Stop => "Stop",
+        codex_protocol::protocol::HookEventName::PermissionRequest => "PermissionRequest",
     }
 }
 

--- a/codex-rs/tui_app_server/src/main.rs
+++ b/codex-rs/tui_app_server/src/main.rs
@@ -22,6 +22,9 @@ fn main() -> anyhow::Result<()> {
             .config_overrides
             .raw_overrides
             .splice(0..0, top_cli.config_overrides.raw_overrides);
+        if inner.config_overrides.settings_file.is_none() {
+            inner.config_overrides.settings_file = top_cli.config_overrides.settings_file;
+        }
         let exit_info = run_main(
             inner,
             arg0_paths,

--- a/codex-rs/utils/cli/src/config_override.rs
+++ b/codex-rs/utils/cli/src/config_override.rs
@@ -7,6 +7,8 @@
 //! key/value pairs as well as to apply them onto a mutable
 //! `serde_json::Value` representing the configuration tree.
 
+use std::path::PathBuf;
+
 use clap::ArgAction;
 use clap::Parser;
 use serde::de::Error as SerdeError;
@@ -34,6 +36,12 @@ pub struct CliConfigOverrides {
         global = true,
     )]
     pub raw_overrides: Vec<String>,
+
+    /// Path to a JSON settings file containing additional hook definitions,
+    /// merged additively with existing config. Used by external supervisors
+    /// to inject per-session hooks.
+    #[clap(skip)]
+    pub settings_file: Option<PathBuf>,
 }
 
 impl CliConfigOverrides {


### PR DESCRIPTION
## Summary
- **Gap 1 — PermissionRequest hook event**: New hook fires when the agent pauses for user approval, enabling external supervisors (e.g. Looper) to detect blocked agents. Dispatches before the `ExecApprovalRequest` event, supports `tool_name` matchers, notification-only (no blocking).
- **Gap 2 — `--settings` CLI flag**: Accepts a JSON settings file path containing hook definitions merged additively with existing config. Enables per-session hook injection so supervisors can attribute events to specific agent instances.
- Updated all output schema fixtures to include the new `PermissionRequest` variant in `HookEventNameWire`, and added the `permission-request.command.input.schema.json` fixture.

## Test plan
- [x] `codex-hooks` crate: 58/58 tests pass (including schema fixture and turn_id extension tests)
- [x] `codex-protocol`, `codex-app-server-protocol`, `codex-utils-cli` type-check successfully
- [x] `codex-core` type-checks successfully (full test suite requires `libcap-dev` — CI will validate)
- [ ] CI passes full test suite

Closes jeanibarz/looper#86

🤖 Generated with [Claude Code](https://claude.com/claude-code)