### PR TITLE
fix(hooks): dispatch --settings JSON hooks in headless exec mode

### DIFF
--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -2523,6 +2523,7 @@ impl CodexMessageProcessor {
             developer_instructions,
             personality,
         );
+        self.apply_process_thread_config_overrides(&mut typesafe_overrides);
         typesafe_overrides.ephemeral = ephemeral;
         let listener_task_context = ListenerTaskContext {
             thread_manager: Arc::clone(&self.thread_manager),
@@ -2959,6 +2960,12 @@ impl CodexMessageProcessor {
             developer_instructions,
             personality,
             ..Default::default()
+        }
+    }
+
+    fn apply_process_thread_config_overrides(&self, overrides: &mut ConfigOverrides) {
+        if overrides.settings_file.is_none() {
+            overrides.settings_file = self.config.settings_file.clone();
         }
     }
 
@@ -4580,6 +4587,7 @@ impl CodexMessageProcessor {
             &mut typesafe_overrides,
         )
         .await;
+        self.apply_process_thread_config_overrides(&mut typesafe_overrides);
 
         // Derive a Config using the same logic as new conversation, honoring overrides if provided.
         let config = match self

--- a/codex-rs/exec/tests/suite/hooks.rs
+++ b/codex-rs/exec/tests/suite/hooks.rs
@@ -1,0 +1,100 @@
+#![cfg(not(target_os = "windows"))]
+#![allow(clippy::expect_used)]
+
+use core_test_support::responses;
+use core_test_support::test_codex_exec::test_codex_exec;
+use pretty_assertions::assert_eq;
+use serde_json::Value;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn exec_settings_file_hooks_fire_for_shell_command() -> anyhow::Result<()> {
+    let test = test_codex_exec();
+    let hook_log = test.cwd_path().join("hook-fired.jsonl");
+    let settings_path = test.cwd_path().join("settings.json");
+    let hook_log_display = hook_log.display();
+    let hook_command = format!(
+        "payload=$(cat); printf '%s\\n' \"$payload\" >> {hook_log_display}"
+    );
+    let settings = serde_json::json!({
+        "hooks": {
+            "PreToolUse": [{
+                "matcher": "*",
+                "hooks": [{ "type": "command", "command": hook_command }]
+            }],
+            "PostToolUse": [{
+                "matcher": "*",
+                "hooks": [{ "type": "command", "command": hook_command }]
+            }]
+        }
+    });
+    std::fs::write(&settings_path, serde_json::to_vec_pretty(&settings)?)?;
+
+    let server = responses::start_mock_server().await;
+    let server_uri = server.uri();
+    std::fs::write(
+        test.home_path().join("config.toml"),
+        format!(
+            r#"model_provider = "mock"
+
+[model_providers.mock]
+name = "mock"
+base_url = "{server_uri}/v1"
+env_key = "CODEX_API_KEY"
+wire_api = "responses"
+supports_websockets = false
+"#
+        ),
+    )?;
+    responses::mount_sse_sequence(
+        &server,
+        vec![
+            responses::sse(vec![
+                responses::ev_response_created("resp-1"),
+                responses::ev_shell_command_call("call-1", "echo hello"),
+                responses::ev_completed("resp-1"),
+            ]),
+            responses::sse(vec![
+                responses::ev_response_created("resp-2"),
+                responses::ev_assistant_message("msg-1", "done"),
+                responses::ev_completed("resp-2"),
+            ]),
+        ],
+    )
+    .await;
+
+    test.cmd()
+        .arg("--settings")
+        .arg(&settings_path)
+        .arg("-c")
+        .arg("features.codex_hooks=true")
+        .arg("--skip-git-repo-check")
+        .arg("-s")
+        .arg("danger-full-access")
+        .arg("-m")
+        .arg("gpt-5.1")
+        .arg("run a shell command")
+        .assert()
+        .success();
+
+    let hook_log_contents = std::fs::read_to_string(&hook_log)?;
+    let hook_events = hook_log_contents
+        .lines()
+        .map(serde_json::from_str::<Value>)
+        .collect::<Result<Vec<_>, _>>()?;
+
+    assert_eq!(
+        hook_events
+            .iter()
+            .map(|event| event["hook_event_name"].as_str().expect("hook event name"))
+            .collect::<Vec<_>>(),
+        vec!["PreToolUse", "PostToolUse"]
+    );
+    assert_eq!(hook_events[0]["tool_name"], "Bash");
+    assert_eq!(hook_events[0]["tool_use_id"], "call-1");
+    assert_eq!(hook_events[0]["tool_input"]["command"], "echo hello");
+    assert_eq!(hook_events[1]["tool_name"], "Bash");
+    assert_eq!(hook_events[1]["tool_use_id"], "call-1");
+    assert_eq!(hook_events[1]["tool_input"]["command"], "echo hello");
+
+    Ok(())
+}

--- a/codex-rs/exec/tests/suite/mod.rs
+++ b/codex-rs/exec/tests/suite/mod.rs
@@ -3,6 +3,7 @@ mod add_dir;
 mod apply_patch;
 mod auth_env;
 mod ephemeral;
+mod hooks;
 mod mcp_required_exit;
 mod originator;
 mod output_schema;


### PR DESCRIPTION
Closes #27

## Diagnosis

`codex exec --settings FILE` parsed the Claude-compatible settings file into the outer exec `Config`, but the headless exec path starts an in-process app-server and then creates the actual thread through `thread/start`. On the Claude-compat branch, `CodexMessageProcessor::thread_start` and `thread_resume` rebuild per-thread `ConfigOverrides` from request params and did not carry the process-level `settings_file` through. As a result, `Hooks::new(HooksConfig { settings_file: config.settings_file.clone(), ... })` saw `None`, so `ClaudeHooksEngine` never discovered the settings-file handlers and hook dispatch looked like a silent no-op.

This patch carries the process `settings_file` into app-server thread config when the thread request did not override it, covering new and resumed headless threads. The compat branch already has warning notification handling for `EventMsg::Warning`, so the rebased patch does not need the extra warning bridge that was necessary on `main`.

## Repro Evidence

Pre-fix, the mock Responses repro executed the shell command but did not create `/tmp/hook-fired.jsonl`:

```text
exec
/bin/bash -lc 'echo hello' ... succeeded:
hello

/tmp/hook-fired.jsonl: No such file or directory
```

After the fix, settings-file hooks fire for the headless exec path. The regression asserts both events from the hook log:

```json
{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"echo hello"},"tool_use_id":"call-1"}
{"hook_event_name":"PostToolUse","tool_name":"Bash","tool_input":{"command":"echo hello"},"tool_response":"hello\n","tool_use_id":"call-1"}
```

## Tests

```text
CARGO_INCREMENTAL=0 cargo test -p codex-exec exec_settings_file_hooks_fire_for_shell_command -- --nocapture
# test suite::hooks::exec_settings_file_hooks_fire_for_shell_command ... ok
# test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 61 filtered out
```

Earlier on the `main`-based version of this patch, these also passed before rebasing: `cargo test -p codex-hooks`, `cargo build -p codex-cli`, and `cargo test -p codex-app-server`. `cargo fmt -- --check` remains unusable in this checkout under stable rustfmt because the repo config requests unstable `imports_granularity = Item` and reports broad import-order diffs in read-only mode.

## Deploy after merge

# After merge, the maintainer must rebuild the Looper-installed binary:
cd ~/git/codex && git pull origin feat/claude-compat && cd ~/git/looper && pnpm codex:rebuild
pnpm prod:update  # restart Looper to pick up the new binary

## Scope

This does not add new hook events (#2), change CLAUDE.md loading (#1), or change `.claude-plugin` / plugin marketplace behavior (#11/#13).
