### PR TITLE
fix(core-plugins): support claude marketplace manifests

### DIFF
--- a/codex-rs/core-plugins/src/loader.rs
+++ b/codex-rs/core-plugins/src/loader.rs
@@ -2,6 +2,7 @@ use crate::OPENAI_CURATED_MARKETPLACE_NAME;
 use crate::manifest::PluginManifestPaths;
 use crate::manifest::load_plugin_manifest;
 use crate::marketplace::MarketplacePluginSource;
+use crate::marketplace::find_marketplace_manifest_path;
 use crate::marketplace::list_marketplaces;
 use crate::marketplace::load_marketplace;
 use crate::store::PluginStore;
@@ -147,12 +148,9 @@ pub fn refresh_curated_plugin_cache(
 ) -> Result<bool, String> {
     let cache_plugin_version = curated_plugin_cache_version(plugin_version);
     let store = PluginStore::try_new(codex_home.to_path_buf()).map_err(|err| err.to_string())?;
-    let curated_marketplace_path = AbsolutePathBuf::try_from(
-        codex_home
-            .join(".tmp/plugins")
-            .join(".agents/plugins/marketplace.json"),
-    )
-    .map_err(|_| "local curated marketplace is not available".to_string())?;
+    let curated_repo_root = codex_home.join(".tmp/plugins");
+    let curated_marketplace_path = find_marketplace_manifest_path(&curated_repo_root)
+        .ok_or_else(|| "local curated marketplace is not available".to_string())?;
     let curated_marketplace = load_marketplace(&curated_marketplace_path)
         .map_err(|err| format!("failed to load curated marketplace for cache refresh: {err}"))?;
 
@@ -1109,6 +1107,51 @@ mod tests {
             "export-backup"
         );
         assert_eq!(curated_plugin_cache_version("0123456"), "0123456");
+    }
+
+    #[test]
+    fn refresh_curated_plugin_cache_loads_claude_layout_marketplace() {
+        let codex_home = tempfile::tempdir().expect("create codex home");
+        let curated_root = codex_home.path().join(".tmp/plugins");
+        let plugin_root = curated_root.join("plugins/sample");
+        fs::create_dir_all(curated_root.join(".claude/plugins"))
+            .expect("create marketplace dir");
+        fs::create_dir_all(plugin_root.join(".codex-plugin")).expect("create plugin manifest dir");
+        fs::write(
+            curated_root.join(".claude/plugins/marketplace.json"),
+            r#"{
+  "name": "openai-curated",
+  "plugins": [
+    {
+      "name": "sample",
+      "source": {
+        "source": "local",
+        "path": "./plugins/sample"
+      }
+    }
+  ]
+}"#,
+        )
+        .expect("write marketplace");
+        fs::write(
+            plugin_root.join(".codex-plugin/plugin.json"),
+            r#"{"name":"sample","version":"0.1.0"}"#,
+        )
+        .expect("write plugin manifest");
+        let plugin_id =
+            PluginId::new("sample".to_string(), OPENAI_CURATED_MARKETPLACE_NAME.to_string())
+                .expect("valid plugin id");
+
+        let refreshed =
+            refresh_curated_plugin_cache(codex_home.path(), "2026-04-26", &[plugin_id.clone()])
+                .expect("refresh curated plugin cache");
+
+        assert!(refreshed);
+        let store = PluginStore::try_new(codex_home.path().to_path_buf()).expect("plugin store");
+        let active_root = store
+            .active_plugin_root(&plugin_id)
+            .expect("active plugin root");
+        assert!(active_root.join(".codex-plugin/plugin.json").is_file());
     }
 
     #[test]

--- a/codex-rs/core-plugins/src/marketplace_add.rs
+++ b/codex-rs/core-plugins/src/marketplace_add.rs
@@ -217,6 +217,7 @@ where
 mod tests {
     use super::*;
     use anyhow::Result;
+    use crate::marketplace::find_marketplace_manifest_path;
     use pretty_assertions::assert_eq;
     use tempfile::TempDir;
 
@@ -242,13 +243,7 @@ mod tests {
         assert_eq!(result.marketplace_name, "debug");
         assert_eq!(result.source_display, "https://github.com/owner/repo.git");
         assert!(!result.already_added);
-        assert!(
-            result
-                .installed_root
-                .as_path()
-                .join(".agents/plugins/marketplace.json")
-                .is_file()
-        );
+        assert!(find_marketplace_manifest_path(result.installed_root.as_path()).is_some());
 
         let config = fs::read_to_string(codex_home.path().join(codex_config::CONFIG_TOML_FILE))?;
         assert!(config.contains("[marketplaces.debug]"));

--- a/codex-rs/core-plugins/src/marketplace_tests.rs
+++ b/codex-rs/core-plugins/src/marketplace_tests.rs
@@ -6,9 +6,17 @@ use tempfile::tempdir;
 
 const ALTERNATE_MARKETPLACE_RELATIVE_PATH: &str = ".claude-plugin/marketplace.json";
 const ALTERNATE_PLUGIN_MANIFEST_RELATIVE_PATH: &str = ".claude-plugin/plugin.json";
+const CLAUDE_MARKETPLACE_RELATIVE_PATH: &str = ".claude/plugins/marketplace.json";
 
 fn write_alternate_marketplace(repo_root: &Path, contents: &str) -> AbsolutePathBuf {
     let marketplace_path = repo_root.join(ALTERNATE_MARKETPLACE_RELATIVE_PATH);
+    fs::create_dir_all(marketplace_path.parent().unwrap()).unwrap();
+    fs::write(&marketplace_path, contents).unwrap();
+    AbsolutePathBuf::try_from(marketplace_path).unwrap()
+}
+
+fn write_claude_marketplace(repo_root: &Path, contents: &str) -> AbsolutePathBuf {
+    let marketplace_path = repo_root.join(CLAUDE_MARKETPLACE_RELATIVE_PATH);
     fs::create_dir_all(marketplace_path.parent().unwrap()).unwrap();
     fs::write(&marketplace_path, contents).unwrap();
     AbsolutePathBuf::try_from(marketplace_path).unwrap()
@@ -502,6 +510,18 @@ fn list_marketplaces_prefers_first_supported_manifest_layout() {
   ]
 }"#,
     );
+    let claude_marketplace_path = write_claude_marketplace(
+        &repo_root,
+        r#"{
+  "name": "claude-marketplace",
+  "plugins": [
+    {
+      "name": "claude-plugin",
+      "source": "./plugins/claude-plugin"
+    }
+  ]
+}"#,
+    );
 
     let marketplaces = list_marketplaces_with_home(
         &[AbsolutePathBuf::try_from(repo_root.clone()).unwrap()],
@@ -511,11 +531,8 @@ fn list_marketplaces_prefers_first_supported_manifest_layout() {
     .marketplaces;
 
     assert_eq!(marketplaces.len(), 1);
-    assert_eq!(marketplaces[0].name, "agents-marketplace");
-    assert_eq!(
-        marketplaces[0].path,
-        AbsolutePathBuf::try_from(repo_root.join(".agents/plugins/marketplace.json")).unwrap()
-    );
+    assert_eq!(marketplaces[0].name, "claude-marketplace");
+    assert_eq!(marketplaces[0].path, claude_marketplace_path);
 }
 
 #[test]

--- a/codex-rs/core-plugins/src/marketplace_upgrade.rs
+++ b/codex-rs/core-plugins/src/marketplace_upgrade.rs
@@ -6,6 +6,7 @@ use self::activation::installed_marketplace_metadata_matches;
 use self::activation::write_installed_marketplace_metadata;
 use self::git::clone_git_source;
 use self::git::git_remote_revision;
+use crate::marketplace::find_marketplace_manifest_path;
 use crate::marketplace::validate_marketplace_root;
 use codex_config::CONFIG_TOML_FILE;
 use codex_config::ConfigLayerStack;
@@ -176,9 +177,7 @@ fn upgrade_configured_git_marketplace(
         MARKETPLACE_UPGRADE_GIT_TIMEOUT,
     )?;
     let destination = install_root.join(&marketplace.name);
-    if destination
-        .join(".agents/plugins/marketplace.json")
-        .is_file()
+    if find_marketplace_manifest_path(&destination).is_some()
         && marketplace.last_revision.as_deref() == Some(remote_revision.as_str())
         && installed_marketplace_metadata_matches(&destination, marketplace, &remote_revision)
     {

--- a/codex-rs/core-plugins/src/startup_sync.rs
+++ b/codex-rs/core-plugins/src/startup_sync.rs
@@ -15,6 +15,8 @@ use zip::ZipArchive;
 
 use codex_login::default_client::build_reqwest_client;
 
+use crate::marketplace::find_marketplace_manifest_path;
+
 const GITHUB_API_BASE_URL: &str = "https://api.github.com";
 const GITHUB_API_ACCEPT_HEADER: &str = "application/vnd.github+json";
 const GITHUB_API_VERSION_HEADER: &str = "2022-11-28";
@@ -222,9 +224,7 @@ fn sync_openai_plugins_repo_via_backup_archive(
 }
 
 pub fn has_local_curated_plugins_snapshot(codex_home: &Path) -> bool {
-    curated_plugins_repo_path(codex_home)
-        .join(".agents/plugins/marketplace.json")
-        .is_file()
+    find_marketplace_manifest_path(curated_plugins_repo_path(codex_home).as_path()).is_some()
         && codex_home.join(CURATED_PLUGINS_SHA_FILE).is_file()
 }
 
@@ -369,12 +369,12 @@ fn emit_curated_plugins_startup_sync_counter(
 }
 
 fn ensure_marketplace_manifest_exists(repo_path: &Path) -> Result<(), String> {
-    if repo_path.join(".agents/plugins/marketplace.json").is_file() {
+    if find_marketplace_manifest_path(repo_path).is_some() {
         return Ok(());
     }
     Err(format!(
-        "curated plugins archive missing marketplace manifest at {}",
-        repo_path.join(".agents/plugins/marketplace.json").display()
+        "curated plugins archive missing supported marketplace manifest under {}",
+        repo_path.display()
     ))
 }
 

--- a/codex-rs/core-plugins/src/startup_sync_tests.rs
+++ b/codex-rs/core-plugins/src/startup_sync_tests.rs
@@ -179,7 +179,7 @@ async fn run_http_sync(
 }
 
 fn assert_curated_gmail_repo(repo_path: &Path) {
-    assert!(repo_path.join(".agents/plugins/marketplace.json").is_file());
+    assert!(find_marketplace_manifest_path(repo_path).is_some());
     assert!(
         repo_path
             .join("plugins/gmail/.codex-plugin/plugin.json")
@@ -206,6 +206,21 @@ fn read_curated_plugins_sha_reads_trimmed_sha_file() {
         read_curated_plugins_sha(tmp.path()).as_deref(),
         Some("abc123")
     );
+}
+
+#[test]
+fn local_curated_snapshot_accepts_claude_marketplace_layout() {
+    let tmp = tempdir().expect("tempdir");
+    let repo_path = curated_plugins_repo_path(tmp.path());
+    write_file(
+        &repo_path.join(".claude/plugins/marketplace.json"),
+        r#"{"name":"openai-curated","plugins":[]}"#,
+    );
+    write_curated_plugin_sha(tmp.path());
+
+    assert!(has_local_curated_plugins_snapshot(tmp.path()));
+    ensure_marketplace_manifest_exists(repo_path.as_path())
+        .expect("claude marketplace layout should be supported");
 }
 
 #[cfg(unix)]
@@ -562,7 +577,7 @@ async fn sync_openai_plugins_repo_skips_archive_download_when_sha_matches() {
     .expect("sync should succeed");
 
     assert_eq!(read_curated_plugins_sha(tmp.path()).as_deref(), Some(sha));
-    assert!(repo_path.join(".agents/plugins/marketplace.json").is_file());
+    assert!(find_marketplace_manifest_path(repo_path.as_path()).is_some());
 }
 
 #[tokio::test]


### PR DESCRIPTION
Refs #11

## Summary

This is a scoped slice of `.claude/` compatibility for plugin marketplaces. It removes remaining production assumptions that curated/installed marketplace manifests must live at `.agents/plugins/marketplace.json` and routes those checks through the existing supported-layout resolver, which already prefers `.claude/plugins/marketplace.json`.

## Audit

Already wired on `feat/claude-compat`:
- `.claude/skills/` discovery is already present: `codex-rs/core-skills/src/loader.rs:106-110`, user roots at `codex-rs/core-skills/src/loader.rs:295-308`, and repo roots at `codex-rs/core-skills/src/loader.rs:350-356`.
- `.claude/agents/` discovery is already present: `codex-rs/core/src/config/agent_roles.rs:112-136`.
- `.claude-plugin/plugin.json` parsing is already present in tests around `codex-rs/core-plugins/src/manifest.rs:393`.
- Marketplace discovery already supports `.claude/plugins/marketplace.json` before `.agents/plugins/marketplace.json`: `codex-rs/core-plugins/src/marketplace.rs:20-24` and resolver at `codex-rs/core-plugins/src/marketplace.rs:238-247`.

Implemented here:
- `refresh_curated_plugin_cache` now resolves the curated marketplace manifest through `find_marketplace_manifest_path` instead of a hardcoded `.agents/...` path: `codex-rs/core-plugins/src/loader.rs:151-153`.
- Curated startup snapshot checks now accept any supported marketplace layout: `codex-rs/core-plugins/src/startup_sync.rs:226-228`, `codex-rs/core-plugins/src/startup_sync.rs:371-378`.
- Marketplace auto-upgrade no-op detection now accepts any supported installed manifest layout: `codex-rs/core-plugins/src/marketplace_upgrade.rs:179-182`.
- Tests cover `.claude/plugins/marketplace.json` precedence and cache/snapshot behavior: `codex-rs/core-plugins/src/marketplace_tests.rs:513-535`, `codex-rs/core-plugins/src/loader.rs:1112-1154`, `codex-rs/core-plugins/src/startup_sync_tests.rs:211-223`.

Deferred:
- `.claude/commands/` slash-command discovery. The current TUI slash command path is built-in only (`codex-rs/tui/src/bottom_pane/slash_commands.rs:27-29`, `codex-rs/tui/src/slash_command.rs:223-228`), so custom commands are not a small patch.
- `.claude/rules/` conditional instructions.
- `discover_claude_config` config flag. Existing skills/agents compatibility is currently unconditional, so changing it needs a separate compatibility decision.

## Verification

- `cargo test -p codex-core-plugins`
  - Passed: `test result: ok. 102 passed; 0 failed; 0 ignored`.
- `git diff --check`
  - Passed.
- `cargo fmt -- --check core-plugins/src/loader.rs core-plugins/src/marketplace_add.rs core-plugins/src/marketplace_tests.rs core-plugins/src/marketplace_upgrade.rs core-plugins/src/startup_sync.rs core-plugins/src/startup_sync_tests.rs`
  - Not usable in this workspace under stable rustfmt: it ignored the file list and reported workspace-wide import churn plus `imports_granularity = Item` unstable-option warnings. No unrelated files were modified.
- `CARGO_INCREMENTAL=0 cargo build -p codex-cli --release`
  - Attempted, but failed due local disk exhaustion: `No space left on device` while writing release build artifacts. I removed only generated release artifacts afterward with `cargo clean --release`.

## Scope Fence

This PR intentionally does not touch hooks, `CLAUDE.md` fallback, `.claude-plugin/plugin.json` parsing, hook event types, `.claude/skills/`, or `.claude/agents/` discovery.

## After Merge

The maintainer must rebuild the Looper-installed binary:

```bash
cd ~/git/codex && git pull origin feat/claude-compat && cd ~/git/looper && pnpm codex:rebuild
pnpm prod:update  # restart Looper to pick up the new binary
```