### PR TITLE
fix(core-plugins): load Claude enabled plugin roots

### DIFF
--- a/codex-rs/core-plugins/src/claude.rs
+++ b/codex-rs/core-plugins/src/claude.rs
@@ -1,0 +1,203 @@
+use crate::marketplace::find_marketplace_manifest_path;
+use crate::marketplace::find_marketplace_plugin;
+use crate::marketplace::MarketplacePluginSource;
+use codex_plugin::PluginId;
+use codex_utils_absolute_path::AbsolutePathBuf;
+use serde::Deserialize;
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+use tracing::warn;
+
+const CLAUDE_SETTINGS_RELATIVE_PATH: &str = ".claude/settings.json";
+const CLAUDE_MARKETPLACES_RELATIVE_PATH: &str = ".claude/plugins/marketplaces";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClaudeEnabledPlugin {
+    pub plugin_id: PluginId,
+    pub source_path: AbsolutePathBuf,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ClaudeSettings {
+    #[serde(default)]
+    enabled_plugins: BTreeMap<String, bool>,
+}
+
+pub fn enabled_claude_plugin_roots(home_dir: Option<&Path>) -> Vec<ClaudeEnabledPlugin> {
+    let Some(home_dir) = home_dir else {
+        return Vec::new();
+    };
+    let settings_path = home_dir.join(CLAUDE_SETTINGS_RELATIVE_PATH);
+    let contents = match fs::read_to_string(&settings_path) {
+        Ok(contents) => contents,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Vec::new(),
+        Err(err) => {
+            warn!(
+                path = %settings_path.display(),
+                "failed to read Claude settings while loading Claude plugins: {err}"
+            );
+            return Vec::new();
+        }
+    };
+    let settings = match serde_json::from_str::<ClaudeSettings>(&contents) {
+        Ok(settings) => settings,
+        Err(err) => {
+            warn!(
+                path = %settings_path.display(),
+                "failed to parse Claude settings while loading Claude plugins: {err}"
+            );
+            return Vec::new();
+        }
+    };
+
+    let mut plugins = settings
+        .enabled_plugins
+        .into_iter()
+        .filter(|(_, enabled)| *enabled)
+        .filter_map(|(plugin_key, _)| enabled_claude_plugin_root(home_dir, plugin_key))
+        .collect::<Vec<_>>();
+    plugins.sort_unstable_by_key(|plugin| plugin.plugin_id.as_key());
+    plugins.dedup_by(|left, right| left.plugin_id == right.plugin_id);
+    plugins
+}
+
+fn enabled_claude_plugin_root(home_dir: &Path, plugin_key: String) -> Option<ClaudeEnabledPlugin> {
+    let plugin_id = match PluginId::parse(&plugin_key) {
+        Ok(plugin_id) => plugin_id,
+        Err(err) => {
+            warn!(
+                plugin = plugin_key,
+                "ignoring invalid Claude enabled plugin key: {err}"
+            );
+            return None;
+        }
+    };
+
+    let marketplace_root = home_dir
+        .join(CLAUDE_MARKETPLACES_RELATIVE_PATH)
+        .join(&plugin_id.marketplace_name);
+    let Some(marketplace_path) = find_marketplace_manifest_path(&marketplace_root) else {
+        warn!(
+            plugin = plugin_key,
+            marketplace = %marketplace_root.display(),
+            "ignoring Claude enabled plugin because marketplace manifest is missing"
+        );
+        return None;
+    };
+    let resolved = match find_marketplace_plugin(&marketplace_path, &plugin_id.plugin_name) {
+        Ok(resolved) => resolved,
+        Err(err) => {
+            warn!(
+                plugin = plugin_key,
+                path = %marketplace_path.display(),
+                "ignoring Claude enabled plugin because marketplace resolution failed: {err}"
+            );
+            return None;
+        }
+    };
+
+    match resolved.source {
+        MarketplacePluginSource::Local { path } => {
+            if path.as_path().is_dir() {
+                Some(ClaudeEnabledPlugin {
+                    plugin_id,
+                    source_path: path,
+                })
+            } else {
+                warn!(
+                    plugin = plugin_key,
+                    path = %path.display(),
+                    "ignoring Claude enabled plugin because source path is missing"
+                );
+                None
+            }
+        }
+        MarketplacePluginSource::Git { .. } => {
+            warn!(
+                plugin = plugin_key,
+                "ignoring Claude enabled plugin because Codex cannot load a Git source directly from Claude settings"
+            );
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::enabled_claude_plugin_roots;
+    use codex_plugin::PluginId;
+    use codex_utils_absolute_path::AbsolutePathBuf;
+    use pretty_assertions::assert_eq;
+    use std::fs;
+    use std::path::Path;
+    use tempfile::tempdir;
+
+    fn write_file(path: &Path, contents: &str) {
+        fs::create_dir_all(path.parent().expect("parent")).expect("mkdir");
+        fs::write(path, contents).expect("write file");
+    }
+
+    #[test]
+    fn resolves_enabled_plugins_from_claude_marketplaces() {
+        let home = tempdir().expect("tempdir");
+        let plugin_root = home
+            .path()
+            .join(".claude/plugins/marketplaces/looper/plugin");
+
+        write_file(
+            &home.path().join(".claude/settings.json"),
+            r#"{
+  "enabledPlugins": {
+    "looper-toolkit@looper": true
+  }
+}"#,
+        );
+        write_file(
+            &home
+                .path()
+                .join(".claude/plugins/marketplaces/looper/.claude-plugin/marketplace.json"),
+            r#"{
+  "name": "looper",
+  "plugins": [
+    {
+      "name": "looper-toolkit",
+      "source": "./plugin"
+    }
+  ]
+}"#,
+        );
+        write_file(
+            &plugin_root.join(".claude-plugin/plugin.json"),
+            r#"{"name":"looper-toolkit"}"#,
+        );
+
+        let plugins = enabled_claude_plugin_roots(Some(home.path()));
+
+        assert_eq!(plugins.len(), 1);
+        assert_eq!(
+            plugins[0].plugin_id,
+            PluginId::parse("looper-toolkit@looper").expect("plugin id")
+        );
+        assert_eq!(
+            plugins[0].source_path,
+            AbsolutePathBuf::try_from(plugin_root).expect("absolute path")
+        );
+    }
+
+    #[test]
+    fn ignores_disabled_claude_plugins() {
+        let home = tempdir().expect("tempdir");
+        write_file(
+            &home.path().join(".claude/settings.json"),
+            r#"{
+  "enabledPlugins": {
+    "looper-toolkit@looper": false
+  }
+}"#,
+        );
+
+        assert_eq!(enabled_claude_plugin_roots(Some(home.path())), Vec::new());
+    }
+}

--- a/codex-rs/core-plugins/src/lib.rs
+++ b/codex-rs/core-plugins/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod claude;
 pub mod installed_marketplaces;
 pub mod loader;
 pub mod manifest;

--- a/codex-rs/core-plugins/src/loader.rs
+++ b/codex-rs/core-plugins/src/loader.rs
@@ -1,21 +1,22 @@
-use crate::OPENAI_CURATED_MARKETPLACE_NAME;
-use crate::manifest::PluginManifestPaths;
+use crate::claude::enabled_claude_plugin_roots;
 use crate::manifest::load_plugin_manifest;
-use crate::marketplace::MarketplacePluginSource;
+use crate::manifest::PluginManifestPaths;
 use crate::marketplace::find_marketplace_manifest_path;
 use crate::marketplace::list_marketplaces;
 use crate::marketplace::load_marketplace;
+use crate::marketplace::MarketplacePluginSource;
 use crate::store::PluginStore;
 use crate::store::plugin_version_for_source;
-use codex_config::ConfigLayerStack;
+use crate::OPENAI_CURATED_MARKETPLACE_NAME;
 use codex_config::types::McpServerConfig;
 use codex_config::types::PluginConfig;
-use codex_core_skills::SkillMetadata;
-use codex_core_skills::config_rules::SkillConfigRules;
+use codex_config::ConfigLayerStack;
 use codex_core_skills::config_rules::resolve_disabled_skill_paths;
 use codex_core_skills::config_rules::skill_config_rules_from_stack;
-use codex_core_skills::loader::SkillRoot;
+use codex_core_skills::config_rules::SkillConfigRules;
 use codex_core_skills::loader::load_skills_from_roots;
+use codex_core_skills::loader::SkillRoot;
+use codex_core_skills::SkillMetadata;
 use codex_exec_server::LOCAL_FS;
 use codex_plugin::AppConnectorId;
 use codex_plugin::LoadedPlugin;
@@ -34,6 +35,7 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::fs;
 use std::path::Path;
+use std::path::PathBuf;
 use std::process::Command;
 use std::sync::Arc;
 use tempfile::TempDir;
@@ -111,6 +113,10 @@ pub async fn load_plugins_from_layer_stack(
         .into_iter()
         .collect();
     configured_plugins.sort_unstable_by(|(a, _), (b, _)| a.cmp(b));
+    let configured_plugin_keys = configured_plugins
+        .iter()
+        .map(|(configured_name, _)| configured_name.clone())
+        .collect::<HashSet<_>>();
 
     let mut plugins = Vec::with_capacity(configured_plugins.len());
     let mut seen_mcp_server_names = HashMap::<String, String>::new();
@@ -123,22 +129,54 @@ pub async fn load_plugins_from_layer_stack(
             &skill_config_rules,
         )
         .await;
-        for name in loaded_plugin.mcp_servers.keys() {
-            if let Some(previous_plugin) =
-                seen_mcp_server_names.insert(name.clone(), configured_name.clone())
-            {
-                warn!(
-                    plugin = configured_name,
-                    previous_plugin,
-                    server = name,
-                    "skipping duplicate plugin MCP server name"
-                );
-            }
+        record_mcp_server_names(&loaded_plugin, &mut seen_mcp_server_names);
+        plugins.push(loaded_plugin);
+    }
+
+    let home_dir = claude_plugins_home_dir(config_layer_stack);
+    for claude_plugin in enabled_claude_plugin_roots(home_dir.as_deref()) {
+        let config_name = claude_plugin.plugin_id.as_key();
+        if configured_plugin_keys.contains(&config_name) {
+            continue;
         }
+        let loaded_plugin = load_plugin_from_root(
+            config_name,
+            claude_plugin.source_path,
+            /*enabled*/ true,
+            restriction_product,
+            &skill_config_rules,
+        )
+        .await;
+        record_mcp_server_names(&loaded_plugin, &mut seen_mcp_server_names);
         plugins.push(loaded_plugin);
     }
 
     PluginLoadOutcome::from_plugins(plugins)
+}
+
+fn claude_plugins_home_dir(config_layer_stack: &ConfigLayerStack) -> Option<PathBuf> {
+    config_layer_stack
+        .get_user_layer()
+        .and_then(|layer| layer.config_folder())
+        .and_then(|config_folder| config_folder.as_path().parent().map(Path::to_path_buf))
+}
+
+fn record_mcp_server_names(
+    loaded_plugin: &LoadedPlugin<McpServerConfig>,
+    seen_mcp_server_names: &mut HashMap<String, String>,
+) {
+    for name in loaded_plugin.mcp_servers.keys() {
+        if let Some(previous_plugin) =
+            seen_mcp_server_names.insert(name.clone(), loaded_plugin.config_name.clone())
+        {
+            warn!(
+                plugin = loaded_plugin.config_name,
+                previous_plugin,
+                server = name,
+                "skipping duplicate plugin MCP server name"
+            );
+        }
+    }
 }
 
 pub fn refresh_curated_plugin_cache(
@@ -464,19 +502,7 @@ async fn load_plugin(
             Ok(plugin_id) => store.plugin_base_root(plugin_id),
             Err(_) => store.root().clone(),
         });
-    let mut loaded_plugin = LoadedPlugin {
-        config_name,
-        manifest_name: None,
-        manifest_description: None,
-        root,
-        enabled: plugin.enabled,
-        skill_roots: Vec::new(),
-        disabled_skill_paths: HashSet::new(),
-        has_enabled_skills: false,
-        mcp_servers: HashMap::new(),
-        apps: Vec::new(),
-        error: None,
-    };
+    let mut loaded_plugin = unloaded_plugin(config_name.clone(), root, plugin.enabled);
 
     if !plugin.enabled {
         return loaded_plugin;
@@ -495,6 +521,29 @@ async fn load_plugin(
             return loaded_plugin;
         }
     };
+
+    load_plugin_from_root(
+        config_name,
+        plugin_root,
+        plugin.enabled,
+        restriction_product,
+        skill_config_rules,
+    )
+    .await
+}
+
+async fn load_plugin_from_root(
+    config_name: String,
+    plugin_root: AbsolutePathBuf,
+    enabled: bool,
+    restriction_product: Option<Product>,
+    skill_config_rules: &SkillConfigRules,
+) -> LoadedPlugin<McpServerConfig> {
+    let mut loaded_plugin = unloaded_plugin(config_name, plugin_root.clone(), enabled);
+
+    if !enabled {
+        return loaded_plugin;
+    }
 
     if !plugin_root.as_path().is_dir() {
         loaded_plugin.error = Some("path does not exist or is not a directory".to_string());
@@ -544,6 +593,26 @@ async fn load_plugin(
     loaded_plugin.mcp_servers = mcp_servers;
     loaded_plugin.apps = load_plugin_apps(plugin_root.as_path()).await;
     loaded_plugin
+}
+
+fn unloaded_plugin(
+    config_name: String,
+    root: AbsolutePathBuf,
+    enabled: bool,
+) -> LoadedPlugin<McpServerConfig> {
+    LoadedPlugin {
+        config_name,
+        manifest_name: None,
+        manifest_description: None,
+        root,
+        enabled,
+        skill_roots: Vec::new(),
+        disabled_skill_paths: HashSet::new(),
+        has_enabled_skills: false,
+        mcp_servers: HashMap::new(),
+        apps: Vec::new(),
+        error: None,
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/codex-rs/core/src/plugins/manager_tests.rs
+++ b/codex-rs/core/src/plugins/manager_tests.rs
@@ -245,6 +245,93 @@ async fn load_plugins_loads_default_skills_and_mcp_servers() {
 }
 
 #[tokio::test]
+async fn load_plugins_includes_claude_enabled_plugin_skills() {
+    let home = TempDir::new().unwrap();
+    let codex_home = home.path().join(".codex");
+    let plugin_root = home
+        .path()
+        .join(".claude/plugins/marketplaces/looper/plugin");
+    let skill_path = plugin_root.join("skills/typescript-type-safety/SKILL.md");
+
+    write_file(
+        &codex_home.join(CONFIG_TOML_FILE),
+        r#"
+[features]
+plugins = true
+
+[skills.bundled]
+enabled = false
+"#,
+    );
+    write_file(
+        &home.path().join(".claude/settings.json"),
+        r#"{
+  "enabledPlugins": {
+    "looper-toolkit@looper": true
+  }
+}"#,
+    );
+    write_file(
+        &home
+            .path()
+            .join(".claude/plugins/marketplaces/looper/.claude-plugin/marketplace.json"),
+        r#"{
+  "name": "looper",
+  "plugins": [
+    {
+      "name": "looper-toolkit",
+      "source": "./plugin"
+    }
+  ]
+}"#,
+    );
+    write_file(
+        &plugin_root.join(".claude-plugin/plugin.json"),
+        r#"{
+  "name": "looper-toolkit",
+  "description": "Looper Toolkit"
+}"#,
+    );
+    write_file(
+        &skill_path,
+        "---\nname: typescript-type-safety\ndescription: TypeScript type safety patterns\n---\n",
+    );
+
+    let config = load_config(&codex_home, home.path()).await;
+    let plugins_manager = PluginsManager::new(codex_home.clone());
+    let plugin_outcome = plugins_manager.plugins_for_config(&config).await;
+
+    assert_eq!(
+        plugin_outcome.effective_skill_roots(),
+        vec![plugin_root.join("skills").abs()]
+    );
+    assert_eq!(
+        plugin_outcome.capability_summaries(),
+        &[PluginCapabilitySummary {
+            config_name: "looper-toolkit@looper".to_string(),
+            display_name: "looper-toolkit".to_string(),
+            description: Some("Looper Toolkit".to_string()),
+            has_skills: true,
+            mcp_server_names: Vec::new(),
+            app_connector_ids: Vec::new(),
+        }]
+    );
+
+    let skills_input =
+        crate::skills_load_input_from_config(&config, plugin_outcome.effective_skill_roots());
+    let skills_manager =
+        crate::skills::SkillsManager::new(codex_home.abs(), /*bundled_skills_enabled*/ false);
+    let skills = skills_manager
+        .skills_for_config(&skills_input, /*fs*/ None)
+        .await;
+
+    assert!(skills
+        .skills
+        .iter()
+        .any(|skill| skill.name == "looper-toolkit:typescript-type-safety"));
+}
+
+#[tokio::test]
 async fn load_plugins_resolves_disabled_skill_names_against_loaded_plugin_skills() {
     let codex_home = TempDir::new().unwrap();
     let plugin_root = codex_home


### PR DESCRIPTION
Refs #13

## Summary

- Load Claude Code enabled plugin roots from `~/.claude/settings.json` when plugin support is enabled.
- Resolve those roots through `~/.claude/plugins/marketplaces/<marketplace>` using the existing marketplace manifest path helper.
- Reuse the existing plugin loader path, so Claude plugin skills and `.mcp.json` files flow into the current Codex capability pipeline.

## Audit

### Live behavior before this change

Command:

```bash
/home/jean/bin/codex debug prompt-input "probe" 2>&1 \
  | tee /tmp/issue-13-prompt-input-full.txt \
  | rg -n "looper-toolkit|typescript-type-safety|tdd-workflow|git-commit-discipline|tool_search|skills" \
  > /tmp/issue-13-before.txt
```

Result: the deployed `looper.94c0e92a2` binary did not expose `looper-toolkit:*` skills or the `looper-toolkit` plugin in prompt input.

The real Claude layout was present:

- `/home/jean/.claude/plugins/marketplaces/looper/plugin/.claude-plugin/plugin.json`
- `/home/jean/.claude/plugins/marketplaces/looper/plugin/skills/typescript-type-safety/SKILL.md`
- `/home/jean/.claude/plugins/marketplaces/looper/plugin/skills/tdd-workflow/SKILL.md`
- `/home/jean/.claude/plugins/marketplaces/looper/plugin/skills/git-commit-discipline/SKILL.md`

Claude settings had the plugin enabled:

```json
"enabledPlugins": {
  "looper-toolkit@looper": true
}
```

### Code survey

Already wired:

- `.claude-plugin/plugin.json` discovery via `DISCOVERABLE_PLUGIN_MANIFEST_PATHS`.
- `.claude/plugins/marketplace.json` precedence through `find_marketplace_manifest_path`.
- Plugin-rooted skills are already namespaced by `core-skills`.
- Plugin `.mcp.json` is already loaded by `plugin_mcp_config_paths` once the plugin root reaches `load_plugin_from_root`.

Missing root cause:

- Codex only loaded plugin roots from Codex `[plugins]` config and the Codex plugin store.
- Claude Code `enabledPlugins` entries were never read, so a Claude-installed local plugin never contributed an effective skill root.

Still missing after this PR:

- `commands/` to Codex slash commands.
- `hooks/hooks.json` to Codex hook configuration.
- Git-source Claude marketplace entries are skipped rather than materialized directly.

## Repro Evidence

Release-profile build was attempted as requested:

```bash
CARGO_INCREMENTAL=0 cargo build -p codex-cli --release
```

That build reached final `codex-cli` fat-LTO codegen/link and was killed by the OS:

```text
error: could not compile `codex-cli` (bin "codex")
Caused by:
  process didn't exit successfully: ... (signal: 9, SIGKILL: kill)
```

At the time, swap was full and the final `rustc` process was using roughly 12 GiB RSS. I then ran a non-LTO debug build from the same worktree for behavior verification:

```bash
cargo build -p codex-cli
```

Pass line:

```text
Finished `dev` profile [unoptimized + debuginfo] target(s) in 5m 31s
```

E2E verification command:

```bash
./target/debug/codex debug prompt-input "probe" 2>&1 \
  | tee /tmp/issue-13-after-full.txt \
  | rg -n "looper-toolkit|typescript-type-safety|tdd-workflow|git-commit-discipline|<plugins_instructions>|Available plugins"
```

Representative output:

```text
- looper-toolkit:git-commit-discipline: Git commit hygiene for AI agents ...
- looper-toolkit:tdd-workflow: Implement features using TDD workflow with requirements-first approach ...
- looper-toolkit:typescript-type-safety: TypeScript type safety patterns ...
### Available plugins
- `looper-toolkit`: Curated skills and review subagents for AI-assisted development.
```

## Tests

```text
cargo test -p codex-core-plugins -- --test-threads=1
test result: ok. 104 passed; 0 failed

cargo test -p codex-core load_plugins_includes_claude_enabled_plugin_skills -- --nocapture
test result: ok. 1 passed

git diff --check
passed
```

Notes:

- A plain parallel `cargo test -p codex-core-plugins` hit an existing startup-sync Git test race (`Text file busy` / early EOF). Serial rerun passed.
- `cargo fmt -- --check <changed files>` was run read-only, but Cargo/rustfmt still evaluated broader repo formatting and failed on pre-existing unstable-rustfmt drift. No files were modified by formatting.

## Scope Fence

This PR only loads Claude-enabled local plugin roots into the existing Codex plugin pipeline. It does not touch hook dispatch, add hook event types, alter `CLAUDE.md` fallback, change `.claude/skills` or `.claude/agents` discovery, redo marketplace `.agents`/`.claude` cleanup, or implement command/hook ingestion.

## After Merge

The maintainer must rebuild the Looper-installed binary:

```bash
cd ~/git/codex && git pull origin feat/claude-compat && cd ~/git/looper && pnpm codex:rebuild
pnpm prod:update  # restart Looper to pick up the new binary
```