### PR TITLE
fix(hooks): dispatch settings hooks in interactive codex sessions (#32)

### DIFF
--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -5265,6 +5265,7 @@ impl CodexMessageProcessor {
             /*personality*/ None,
         );
         typesafe_overrides.ephemeral = ephemeral.then_some(true);
+        self.apply_process_thread_config_overrides(&mut typesafe_overrides);
         // Derive a Config using the same logic as new conversation, honoring overrides if provided.
         let config = match self
             .config_manager

--- a/codex-rs/app-server/src/config_manager.rs
+++ b/codex-rs/app-server/src/config_manager.rs
@@ -33,6 +33,7 @@ pub(crate) struct ConfigManager {
     cloud_requirements: Arc<RwLock<CloudRequirementsLoader>>,
     arg0_paths: Arg0DispatchPaths,
     thread_config_loader: Arc<RwLock<Arc<dyn ThreadConfigLoader>>>,
+    process_settings_file: Option<PathBuf>,
     host_name: Option<String>,
 }
 
@@ -74,8 +75,14 @@ impl ConfigManager {
             cloud_requirements: Arc::new(RwLock::new(cloud_requirements)),
             arg0_paths,
             thread_config_loader: Arc::new(RwLock::new(thread_config_loader)),
+            process_settings_file: None,
             host_name,
         }
+    }
+
+    pub(crate) fn with_process_settings_file(mut self, settings_file: Option<PathBuf>) -> Self {
+        self.process_settings_file = settings_file;
+        self
     }
 
     pub(crate) fn codex_home(&self) -> &Path {
@@ -220,6 +227,10 @@ impl ConfigManager {
                     .map(|(key, value)| (key, json_to_toml(value))),
             )
             .collect::<Vec<_>>();
+        let mut typesafe_overrides = typesafe_overrides;
+        if typesafe_overrides.settings_file.is_none() {
+            typesafe_overrides.settings_file = self.process_settings_file.clone();
+        }
 
         let mut config = codex_core::config::ConfigBuilder::default()
             .codex_home(self.codex_home.clone())

--- a/codex-rs/app-server/src/in_process.rs
+++ b/codex-rs/app-server/src/in_process.rs
@@ -392,6 +392,7 @@ fn start_uninitialized(args: InProcessStartArgs) -> InProcessClientHandle {
         let processor_outgoing = Arc::clone(&outgoing_message_sender);
         let auth_manager =
             AuthManager::shared_from_config(args.config.as_ref(), args.enable_codex_api_key_env);
+        let process_settings_file = args.config.settings_file.clone();
         let config_manager = ConfigManager::new(
             args.config.codex_home.to_path_buf(),
             args.cli_overrides,
@@ -399,7 +400,8 @@ fn start_uninitialized(args: InProcessStartArgs) -> InProcessClientHandle {
             args.cloud_requirements,
             args.arg0_paths.clone(),
             args.thread_config_loader,
-        );
+        )
+        .with_process_settings_file(process_settings_file);
         let (processor_tx, mut processor_rx) = mpsc::channel::<ProcessorCommand>(channel_capacity);
         let mut processor_handle = tokio::spawn(async move {
             let processor = Arc::new(MessageProcessor::new(MessageProcessorArgs {

--- a/codex-rs/app-server/src/lib.rs
+++ b/codex-rs/app-server/src/lib.rs
@@ -371,6 +371,7 @@ pub async fn run_main_with_transport(
     session_source: SessionSource,
     auth: AppServerWebsocketAuthSettings,
 ) -> IoResult<()> {
+    let settings_file = cli_config_overrides.settings_file.clone();
     let environment_manager = Arc::new(EnvironmentManager::new(EnvironmentManagerArgs::from_env(
         ExecServerRuntimePaths::from_optional_paths(
             arg0_paths.codex_self_exe.clone(),
@@ -399,7 +400,8 @@ pub async fn run_main_with_transport(
         Default::default(),
         arg0_paths.clone(),
         Arc::new(NoopThreadConfigLoader),
-    );
+    )
+    .with_process_settings_file(settings_file);
     match config_manager
         .load_latest_config(/*fallback_cwd*/ None)
         .await

--- a/codex-rs/app-server/tests/suite/v2/thread_start.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_start.rs
@@ -5,7 +5,14 @@ use app_test_support::PathBufExt;
 use app_test_support::create_mock_responses_server_repeating_assistant;
 use app_test_support::to_response;
 use app_test_support::write_chatgpt_auth;
+use codex_app_server::in_process;
+use codex_app_server::in_process::InProcessServerEvent;
+use codex_app_server::in_process::InProcessStartArgs;
 use codex_app_server_protocol::AskForApproval;
+use codex_app_server_protocol::ClientInfo;
+use codex_app_server_protocol::ClientRequest;
+use codex_app_server_protocol::InitializeCapabilities;
+use codex_app_server_protocol::InitializeParams;
 use codex_app_server_protocol::JSONRPCError;
 use codex_app_server_protocol::JSONRPCMessage;
 use codex_app_server_protocol::JSONRPCResponse;
@@ -20,22 +27,36 @@ use codex_app_server_protocol::ThreadStartedNotification;
 use codex_app_server_protocol::ThreadStatus;
 use codex_app_server_protocol::ThreadStatusChangedNotification;
 use codex_app_server_protocol::TurnEnvironmentParams;
+use codex_app_server_protocol::TurnStartParams;
+use codex_app_server_protocol::UserInput as V2UserInput;
+use codex_arg0::Arg0DispatchPaths;
+use codex_config::NoopThreadConfigLoader;
 use codex_config::types::AuthCredentialsStoreMode;
+use codex_core::config::ConfigBuilder;
+use codex_core::config::ConfigOverrides;
 use codex_core::config::set_project_trust_level;
+use codex_core::config_loader::CloudRequirementsLoader;
+use codex_core::config_loader::LoaderOverrides;
 use codex_core::config_loader::project_trust_key;
+use codex_exec_server::EnvironmentManager;
 use codex_exec_server::LOCAL_FS;
+use codex_feedback::CodexFeedback;
 use codex_git_utils::resolve_root_git_project_for_trust;
 use codex_login::REFRESH_TOKEN_URL_OVERRIDE_ENV_VAR;
 use codex_protocol::config_types::ServiceTier;
 use codex_protocol::config_types::TrustLevel;
 use codex_protocol::openai_models::ReasoningEffort;
+use codex_protocol::protocol::SessionSource;
+use core_test_support::responses;
 use pretty_assertions::assert_eq;
 use serde_json::Value;
 use serde_json::json;
 use std::path::Path;
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::time::Duration;
 use tempfile::TempDir;
+use tokio::time::sleep;
 use tokio::time::timeout;
 use wiremock::Mock;
 use wiremock::MockServer;
@@ -164,6 +185,157 @@ async fn thread_start_creates_thread_and_emits_started() -> Result<()> {
     let started: ThreadStartedNotification =
         serde_json::from_value(notif.params.expect("params must be present"))?;
     assert_eq!(started.thread, thread);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn thread_start_inherits_settings_file_hooks_from_embedded_process() -> Result<()> {
+    let server = responses::start_mock_server().await;
+    let codex_home = TempDir::new()?;
+    create_config_toml_without_approval_policy(codex_home.path(), &server.uri())?;
+
+    let hook_log = codex_home.path().join("hook-fired.jsonl");
+    let settings_path = codex_home.path().join("settings.json");
+    let hook_log_display = hook_log.display();
+    let hook_command = format!("payload=$(cat); printf '%s\\n' \"$payload\" >> {hook_log_display}");
+    let settings = json!({
+        "hooks": {
+            "PreToolUse": [{
+                "matcher": "*",
+                "hooks": [{ "type": "command", "command": hook_command }]
+            }]
+        }
+    });
+    std::fs::write(&settings_path, serde_json::to_vec_pretty(&settings)?)?;
+    responses::mount_sse_sequence(
+        &server,
+        vec![
+            responses::sse(vec![
+                responses::ev_response_created("resp-1"),
+                responses::ev_shell_command_call("call-1", "echo hello"),
+                responses::ev_completed("resp-1"),
+            ]),
+            responses::sse(vec![
+                responses::ev_response_created("resp-2"),
+                responses::ev_assistant_message("msg-1", "done"),
+                responses::ev_completed("resp-2"),
+            ]),
+        ],
+    )
+    .await;
+
+    let loader_overrides = LoaderOverrides::without_managed_config_for_tests();
+    let config = ConfigBuilder::default()
+        .codex_home(codex_home.path().to_path_buf())
+        .fallback_cwd(Some(codex_home.path().to_path_buf()))
+        .harness_overrides(ConfigOverrides {
+            settings_file: Some(settings_path),
+            ..Default::default()
+        })
+        .loader_overrides(loader_overrides.clone())
+        .build()
+        .await?;
+    let client = in_process::start(InProcessStartArgs {
+        arg0_paths: Arg0DispatchPaths::default(),
+        config: Arc::new(config),
+        cli_overrides: Vec::new(),
+        loader_overrides,
+        cloud_requirements: CloudRequirementsLoader::default(),
+        thread_config_loader: Arc::new(NoopThreadConfigLoader),
+        feedback: CodexFeedback::new(),
+        log_db: None,
+        environment_manager: Arc::new(EnvironmentManager::default_for_tests()),
+        config_warnings: Vec::new(),
+        session_source: SessionSource::Cli,
+        enable_codex_api_key_env: false,
+        initialize: InitializeParams {
+            client_info: ClientInfo {
+                name: "codex-tui".to_string(),
+                title: None,
+                version: "0.1.0".to_string(),
+            },
+            capabilities: Some(InitializeCapabilities {
+                experimental_api: true,
+                ..Default::default()
+            }),
+        },
+        channel_capacity: in_process::DEFAULT_IN_PROCESS_CHANNEL_CAPACITY,
+    })
+    .await?;
+
+    let thread_response = match client
+        .request(ClientRequest::ThreadStart {
+            request_id: RequestId::Integer(1),
+            params: ThreadStartParams {
+                model: Some("gpt-5.2".to_string()),
+                ..Default::default()
+            },
+        })
+        .await?
+    {
+        Ok(response) => response,
+        Err(error) => anyhow::bail!("thread/start failed: {}", error.message),
+    };
+    let ThreadStartResponse { thread, .. } = serde_json::from_value(thread_response)?;
+
+    let mut client = client;
+    if let Err(error) = client
+        .request(ClientRequest::TurnStart {
+            request_id: RequestId::Integer(2),
+            params: TurnStartParams {
+                thread_id: thread.id.clone(),
+                input: vec![V2UserInput::Text {
+                    text: "run a shell command".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
+        })
+        .await?
+    {
+        anyhow::bail!("turn/start failed: {}", error.message);
+    }
+
+    timeout(DEFAULT_READ_TIMEOUT, async {
+        loop {
+            let Some(event) = client.next_event().await else {
+                anyhow::bail!("in-process app-server stopped before turn/completed");
+            };
+            if let InProcessServerEvent::ServerNotification(ServerNotification::TurnCompleted(
+                completed,
+            )) = event
+                && completed.thread_id == thread.id
+            {
+                return Ok::<(), anyhow::Error>(());
+            }
+        }
+    })
+    .await??;
+    client.shutdown().await?;
+
+    for _ in 0..20 {
+        if hook_log.exists() {
+            break;
+        }
+        sleep(Duration::from_millis(100)).await;
+    }
+    let hook_log_contents = std::fs::read_to_string(&hook_log)?;
+    let hook_events = hook_log_contents
+        .lines()
+        .map(serde_json::from_str::<Value>)
+        .collect::<Result<Vec<_>, _>>()?;
+
+    assert_eq!(
+        hook_events
+            .iter()
+            .map(|event| event["hook_event_name"].as_str().expect("hook event name"))
+            .collect::<Vec<_>>(),
+        vec!["PreToolUse"]
+    );
+    assert_eq!(hook_events[0]["tool_name"], "Bash");
+    assert_eq!(hook_events[0]["tool_use_id"], "call-1");
+    assert_eq!(hook_events[0]["tool_input"]["command"], "echo hello");
 
     Ok(())
 }


### PR DESCRIPTION
Fixes #32.

## Diagnosis

The interactive TUI embeds the app-server and starts threads through `thread/start`. PR #28 copied the process-level `settings_file` into some thread config overrides, but the app-server config reload path still had no durable notion of the process `--settings` file. Any app-server path that reloaded thread config without explicitly remembering to call the helper could silently lose settings-file hooks. `thread/fork` had exactly that missing merge.

This change stores the process `settings_file` on `ConfigManager`, applies it whenever typed thread config overrides omit one, wires that through both standalone and embedded app-server startup, and adds the missing merge in `thread/fork`.

## Regression test

- `suite::v2::thread_start::thread_start_inherits_settings_file_hooks_from_embedded_process`
- Path: `codex-rs/app-server/tests/suite/v2/thread_start.rs`
- It starts the embedded app-server path used by interactive Codex, passes a settings file containing a `PreToolUse` hook, drives a mocked Bash tool call, and asserts the hook log contains the Bash hook payload.

## Verification

- `cargo test -p codex-app-server --test all thread_start_inherits_settings_file_hooks_from_embedded_process` passed: 1 passed, 0 failed.
- `cargo test -p codex-exec --test all exec_settings_file_hooks_fire_for_shell_command` passed: 1 passed, 0 failed.
- `cargo test -p codex-app-server --test all` completed with 428 passed, 2 failed, 1 ignored. The failing tests were unrelated to this hook path in this local environment:
  - `suite::v2::mcp_server_status::mcp_server_status_list_tools_and_auth_only_skips_slow_inventory_calls`
  - `suite::v2::turn_start::turn_start_emits_thread_scoped_warning_notification_for_trimmed_skills` expected 7 omitted skills, local environment reported 13.
- `$HOME/.cargo/bin/just fmt` completed. It reformatted broadly under this stable rustfmt setup, so unrelated formatting churn was restored before commit.
- `$HOME/.cargo/bin/just fix -p codex-app-server` passed.

## Live repro

Script: `/tmp/repro-codex-32.sh`

Before rebuild from this branch, the installed binary output was:

```text
before: missing-or-empty /tmp/codex-32-hook-fired.jsonl
codex_exit: 124
after: 1 /tmp/codex-32-hook-fired.jsonl
{"session_id":"019dd0d5-dc5b-7203-9c39-ac9c17e0e5a7","transcript_path":"/tmp/codex-32-home/sessions/2026/04/27/rollout-2026-04-27T23-26-09-019dd0d5-dc5b-7203-9c39-ac9c17e0e5a7.jsonl","cwd":"/home/jean/git/codex-issue-32-interactive-hooks","hook_event_name":"SessionStart","model":"gpt-5.1","permission_mode":"bypassPermissions","source":"startup"}
stdout: /tmp/codex-32-repro.out
stderr: /tmp/codex-32-repro.err
```

After `CODEX_SRC=/home/jean/git/codex-issue-32-interactive-hooks pnpm codex:rebuild`, the installed binary output was:

```text
before: missing-or-empty /tmp/codex-32-hook-fired.jsonl
codex_exit: 124
after: 1 /tmp/codex-32-hook-fired.jsonl
{"session_id":"019dd0f8-2251-7ed0-8985-a2ee91bccea0","transcript_path":"/tmp/codex-32-home/sessions/2026/04/28/rollout-2026-04-28T00-03-36-019dd0f8-2251-7ed0-8985-a2ee91bccea0.jsonl","cwd":"/home/jean/git/codex-issue-32-interactive-hooks","hook_event_name":"SessionStart","model":"gpt-5.1","permission_mode":"bypassPermissions","source":"startup"}
stdout: /tmp/codex-32-repro.out
stderr: /tmp/codex-32-repro.err
```

Installed version after rebuild:

```text
codex-cli 0.125.0-alpha.3+looper.181fbae27
```
