### PR TITLE
Fix Looper programmatic Codex input submission

### DIFF
--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -7016,6 +7016,43 @@ mod tests {
         assert!(!composer.is_in_paste_burst());
     }
 
+    /// Behavior: Looper submits programmatic input as a rapid text write followed immediately by
+    /// Enter. When paste-burst handling is disabled for that managed session, the Enter submits
+    /// instead of being captured as a pasted newline.
+    #[test]
+    fn disabled_paste_burst_allows_immediate_programmatic_enter_submit() {
+        use crossterm::event::KeyCode;
+        use crossterm::event::KeyEvent;
+        use crossterm::event::KeyModifiers;
+
+        let (tx, _rx) = unbounded_channel::<AppEvent>();
+        let sender = AppEventSender::new(tx);
+        let mut composer = ChatComposer::new(
+            /*has_input_focus*/ true,
+            sender,
+            /*enhanced_keys_supported*/ false,
+            "Ask Codex to do anything".to_string(),
+            /*disable_paste_burst*/ true,
+        );
+
+        let mut now = Instant::now();
+        let step = Duration::from_millis(1);
+        for ch in "yes, continue".chars() {
+            let _ = composer.handle_input_basic_with_time(
+                KeyEvent::new(KeyCode::Char(ch), KeyModifiers::NONE),
+                now,
+            );
+            now += step;
+        }
+
+        let (result, _) = composer.handle_submission_with_time(/*should_queue*/ false, now);
+        match result {
+            InputResult::Submitted { text, .. } => assert_eq!(text, "yes, continue"),
+            _ => panic!("expected Submitted"),
+        }
+        assert!(!composer.is_in_paste_burst());
+    }
+
     /// Behavior: a small explicit paste inserts text directly (no placeholder), and the submitted
     /// text matches what is visible in the textarea.
     #[test]

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -4842,7 +4842,10 @@ impl ChatWidget {
                 has_input_focus: true,
                 enhanced_keys_supported,
                 placeholder_text: placeholder.clone(),
-                disable_paste_burst: config.disable_paste_burst,
+                disable_paste_burst: effective_disable_paste_burst(
+                    config.disable_paste_burst,
+                    looper_task_id_env().as_deref(),
+                ),
                 animations_enabled: config.animations,
                 skills: None,
             }),
@@ -11004,6 +11007,39 @@ fn extract_first_bold(s: &str) -> Option<String> {
         i += 1;
     }
     None
+}
+
+fn looper_task_id_env() -> Option<std::ffi::OsString> {
+    #[cfg(test)]
+    {
+        None
+    }
+    #[cfg(not(test))]
+    {
+        std::env::var_os("LOOPER_TASK_ID")
+    }
+}
+
+fn effective_disable_paste_burst(
+    configured: bool,
+    looper_task_id: Option<&std::ffi::OsStr>,
+) -> bool {
+    configured || looper_task_id.is_some()
+}
+
+#[cfg(test)]
+mod looper_compat_tests {
+    use super::*;
+
+    #[test]
+    fn looper_managed_sessions_disable_paste_burst() {
+        assert!(effective_disable_paste_burst(
+            /*configured*/ false,
+            Some(std::ffi::OsStr::new("task-1")),
+        ));
+        assert!(effective_disable_paste_burst(/*configured*/ true, None));
+        assert!(!effective_disable_paste_burst(/*configured*/ false, None));
+    }
 }
 
 #[cfg(test)]

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -11037,8 +11037,12 @@ mod looper_compat_tests {
             /*configured*/ false,
             Some(std::ffi::OsStr::new("task-1")),
         ));
-        assert!(effective_disable_paste_burst(/*configured*/ true, None));
-        assert!(!effective_disable_paste_burst(/*configured*/ false, None));
+        assert!(effective_disable_paste_burst(
+            /*configured*/ true, None
+        ));
+        assert!(!effective_disable_paste_burst(
+            /*configured*/ false, None
+        ));
     }
 }
 

--- a/docs/tui-chat-composer.md
+++ b/docs/tui-chat-composer.md
@@ -229,7 +229,11 @@ pastey” (e.g. contains whitespace or is long).
 
 ### Disabling burst detection
 
-`ChatComposer` supports `disable_paste_burst` as an escape hatch.
+`ChatComposer` supports `disable_paste_burst` as an escape hatch. `ChatWidget` also forces that
+escape hatch on for Looper-managed sessions (`LOOPER_TASK_ID` is present), because Looper submits
+programmatic input as rapid text followed immediately by Enter. The TUI cannot observe Looper's
+underlying PTY write boundary after terminal event parsing, so treating that key stream as a
+paste burst would capture the Enter as a pasted newline instead of submitting the message.
 
 When enabled:
 


### PR DESCRIPTION
## Summary
- Disable TUI paste-burst handling for Looper-managed Codex sessions detected via `LOOPER_TASK_ID`
- Preserve the existing paste-burst behavior for normal interactive sessions
- Add regression coverage for the Looper text-plus-Enter submission path

## Root Cause
Looper sends programmatic Codex input as two ordered dtach writes: text bytes followed by carriage return. Codex TUI cannot observe that syscall boundary after crossterm parsing, so the paste-burst heuristic treated the rapid text as paste input and captured the immediate Enter as a pasted newline instead of submitting.

## Verification
- `/home/jean/.cargo/bin/just fmt`
- `cargo test -p codex-tui looper_managed_sessions_disable_paste_burst`
- `cargo test -p codex-tui disabled_paste_burst_allows_immediate_programmatic_enter_submit`
- `cargo test -p codex-tui` currently fails on pre-existing unrelated issues: status snapshots expect `v0.0.0` while this branch reports `v0.125.0-alpha.3`, and `tests::embedded_app_server_turn_start_uses_settings_file_hooks` aborts with stack overflow
- `cargo +1.93.0 build --manifest-path /home/jean/git/codex-looper-submit-enter/codex-rs/Cargo.toml -p codex-cli --release`
- Installed `/mnt/d/cargo-cache/target/release/codex` to `/home/jean/bin/codex`
- Live Looper verification: spawned Codex task `cecea153-b3e2-4e34-9eda-4362082174d6` / agent `looper-11193e97`, then `POST /api/agents/looper-11193e97/message` with `Reply exactly SUBMIT_ENTER_OK.`. Looper snapshot immediately showed the new `user_prompt` and `stop` with `lastMessage: SUBMIT_ENTER_OK`, with no manual Enter.

Fixes #45