### PR TITLE
fix: hide request_user_input outside allowed modes

### DIFF
--- a/codex-rs/core/src/session/review.rs
+++ b/codex-rs/core/src/session/review.rs
@@ -63,6 +63,7 @@ pub(super) async fn spawn_review_thread(
             .enabled(Feature::MultiAgentV2)
             .then_some(config.multi_agent_v2.min_wait_timeout_ms),
     )
+    .with_active_collaboration_mode(parent_turn_context.collaboration_mode.mode)
     .with_agent_type_description(crate::agent::role::spawn_tool_spec::build(
         &config.agent_roles,
     ));

--- a/codex-rs/core/src/session/turn_context.rs
+++ b/codex-rs/core/src/session/turn_context.rs
@@ -231,6 +231,7 @@ impl TurnContext {
                 .enabled(Feature::MultiAgentV2)
                 .then_some(config.multi_agent_v2.min_wait_timeout_ms),
         )
+        .with_active_collaboration_mode(collaboration_mode.mode)
         .with_agent_type_description(crate::agent::role::spawn_tool_spec::build(
             &config.agent_roles,
         ));
@@ -517,6 +518,7 @@ impl Session {
                 .enabled(Feature::MultiAgentV2)
                 .then_some(per_turn_config.multi_agent_v2.min_wait_timeout_ms),
         )
+        .with_active_collaboration_mode(session_configuration.collaboration_mode.mode)
         .with_agent_type_description(crate::agent::role::spawn_tool_spec::build(
             &per_turn_config.agent_roles,
         ));

--- a/codex-rs/core/src/tools/handlers/request_user_input.rs
+++ b/codex-rs/core/src/tools/handlers/request_user_input.rs
@@ -17,6 +17,7 @@ use codex_tools::ToolSpec;
 
 pub struct RequestUserInputHandler {
     pub available_modes: Vec<ModeKind>,
+    pub active_mode: Option<ModeKind>,
 }
 
 impl ToolHandler for RequestUserInputHandler {
@@ -27,6 +28,12 @@ impl ToolHandler for RequestUserInputHandler {
     }
 
     fn spec(&self) -> Option<ToolSpec> {
+        if let Some(active_mode) = self.active_mode
+            && !self.available_modes.contains(&active_mode)
+        {
+            return None;
+        }
+
         Some(create_request_user_input_tool(
             request_user_input_tool_description(&self.available_modes),
         ))

--- a/codex-rs/core/src/tools/handlers/request_user_input_tests.rs
+++ b/codex-rs/core/src/tools/handlers/request_user_input_tests.rs
@@ -24,6 +24,7 @@ async fn multi_agent_v2_request_user_input_rejects_subagent_threads() {
 
     let result = RequestUserInputHandler {
         available_modes: Vec::new(),
+        active_mode: None,
     }
     .handle(ToolInvocation {
         session: Arc::new(session),

--- a/codex-rs/core/src/tools/spec_plan.rs
+++ b/codex-rs/core/src/tools/spec_plan.rs
@@ -203,6 +203,7 @@ pub fn build_tool_registry_builder(
 
     builder.register_handler(Arc::new(RequestUserInputHandler {
         available_modes: config.request_user_input_available_modes.clone(),
+        active_mode: config.active_collaboration_mode,
     }));
 
     if config.request_permissions_tool_enabled {

--- a/codex-rs/core/src/tools/spec_tests.rs
+++ b/codex-rs/core/src/tools/spec_tests.rs
@@ -10,6 +10,7 @@ use codex_features::Features;
 use codex_mcp::CODEX_APPS_MCP_SERVER_NAME;
 use codex_models_manager::bundled_models_response;
 use codex_models_manager::model_info::with_config_overrides;
+use codex_protocol::config_types::ModeKind;
 use codex_protocol::config_types::WebSearchMode;
 use codex_protocol::config_types::WindowsSandboxLevel;
 use codex_protocol::models::PermissionProfile;
@@ -362,6 +363,69 @@ async fn assert_model_tools(
         .map(ToolSpec::name)
         .collect::<Vec<_>>();
     assert_eq!(&tool_names, &expected_tools,);
+}
+
+async fn model_visible_tool_names_for_mode(features: &Features, mode: ModeKind) -> Vec<String> {
+    let model_info = model_info_from_models_json("gpt-5.4").await;
+    let available_models = Vec::new();
+    let tools_config = ToolsConfig::new(&ToolsConfigParams {
+        model_info: &model_info,
+        available_models: &available_models,
+        features,
+        image_generation_tool_auth_allowed: true,
+        web_search_mode: Some(WebSearchMode::Cached),
+        session_source: SessionSource::Cli,
+        permission_profile: &PermissionProfile::Disabled,
+        windows_sandbox_level: WindowsSandboxLevel::Disabled,
+    })
+    .with_active_collaboration_mode(mode);
+    let router = ToolRouter::from_config(
+        &tools_config,
+        ToolRouterParams {
+            mcp_tools: None,
+            deferred_mcp_tools: None,
+            unavailable_called_tools: Vec::new(),
+            parallel_mcp_server_names: std::collections::HashSet::new(),
+            discoverable_tools: None,
+            dynamic_tools: &[],
+        },
+    );
+    router
+        .model_visible_specs()
+        .iter()
+        .map(ToolSpec::name)
+        .map(str::to_string)
+        .collect()
+}
+
+#[tokio::test]
+async fn request_user_input_model_visible_specs_follow_active_mode() {
+    let features = Features::with_defaults();
+
+    let default_tools = model_visible_tool_names_for_mode(&features, ModeKind::Default).await;
+    assert!(
+        !default_tools
+            .iter()
+            .any(|tool| tool == "request_user_input"),
+        "request_user_input should be hidden in Default mode: {default_tools:?}"
+    );
+
+    let plan_tools = model_visible_tool_names_for_mode(&features, ModeKind::Plan).await;
+    assert!(
+        plan_tools.iter().any(|tool| tool == "request_user_input"),
+        "request_user_input should be visible in Plan mode: {plan_tools:?}"
+    );
+
+    let mut default_enabled_features = Features::with_defaults();
+    default_enabled_features.enable(Feature::DefaultModeRequestUserInput);
+    let default_enabled_tools =
+        model_visible_tool_names_for_mode(&default_enabled_features, ModeKind::Default).await;
+    assert!(
+        default_enabled_tools
+            .iter()
+            .any(|tool| tool == "request_user_input"),
+        "request_user_input should be visible in Default mode when enabled: {default_enabled_tools:?}"
+    );
 }
 
 async fn assert_default_model_tools(

--- a/codex-rs/core/tests/suite/request_user_input.rs
+++ b/codex-rs/core/tests/suite/request_user_input.rs
@@ -69,6 +69,139 @@ fn call_output_content_and_success(
     (content, success)
 }
 
+fn tool_names(req: &ResponsesRequest) -> Vec<String> {
+    req.body_json()
+        .get("tools")
+        .and_then(Value::as_array)
+        .map(|tools| {
+            tools
+                .iter()
+                .filter_map(|tool| {
+                    tool.get("name")
+                        .or_else(|| tool.get("type"))
+                        .and_then(Value::as_str)
+                        .map(str::to_string)
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+async fn advertised_tools_for_mode(
+    mode: ModeKind,
+    enable_default_mode_request_user_input: bool,
+) -> anyhow::Result<Vec<String>> {
+    let server = start_mock_server().await;
+    let response = sse(vec![
+        ev_response_created("resp-1"),
+        ev_assistant_message("msg-1", "done"),
+        ev_completed("resp-1"),
+    ]);
+    let mock = responses::mount_sse_once(&server, response).await;
+
+    let mut builder = test_codex().with_config(move |config| {
+        if enable_default_mode_request_user_input {
+            assert!(
+                config
+                    .features
+                    .enable(Feature::DefaultModeRequestUserInput)
+                    .is_ok(),
+                "test config should allow feature update"
+            );
+        }
+    });
+    let TestCodex {
+        codex,
+        cwd,
+        session_configured,
+        ..
+    } = builder.build(&server).await?;
+
+    let session_model = session_configured.model.clone();
+    let (sandbox_policy, permission_profile) =
+        turn_permission_fields(PermissionProfile::Disabled, cwd.path());
+    codex
+        .submit(Op::UserTurn {
+            environments: None,
+            items: vec![UserInput::Text {
+                text: "list tools".into(),
+                text_elements: Vec::new(),
+            }],
+            final_output_json_schema: None,
+            cwd: cwd.path().to_path_buf(),
+            approval_policy: AskForApproval::Never,
+            approvals_reviewer: None,
+            sandbox_policy,
+            permission_profile,
+            model: session_model.clone(),
+            effort: None,
+            summary: None,
+            service_tier: None,
+            collaboration_mode: Some(CollaborationMode {
+                mode,
+                settings: Settings {
+                    model: session_model,
+                    reasoning_effort: None,
+                    developer_instructions: None,
+                },
+            }),
+            personality: None,
+        })
+        .await?;
+
+    wait_for_event(&codex, |event| matches!(event, EventMsg::TurnComplete(_))).await;
+
+    Ok(tool_names(&mock.single_request()))
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn request_user_input_not_advertised_in_default_mode_by_default() -> anyhow::Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let tools = advertised_tools_for_mode(
+        ModeKind::Default,
+        /*enable_default_mode_request_user_input*/ false,
+    )
+    .await?;
+    assert!(
+        !tools.iter().any(|tool| tool == "request_user_input"),
+        "request_user_input should not be advertised in Default mode: {tools:?}"
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn request_user_input_advertised_in_plan_mode() -> anyhow::Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let tools = advertised_tools_for_mode(
+        ModeKind::Plan,
+        /*enable_default_mode_request_user_input*/ false,
+    )
+    .await?;
+    assert!(
+        tools.iter().any(|tool| tool == "request_user_input"),
+        "request_user_input should be advertised in Plan mode: {tools:?}"
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn request_user_input_advertised_in_default_mode_with_feature() -> anyhow::Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let tools = advertised_tools_for_mode(
+        ModeKind::Default,
+        /*enable_default_mode_request_user_input*/ true,
+    )
+    .await?;
+    assert!(
+        tools.iter().any(|tool| tool == "request_user_input"),
+        "request_user_input should be advertised in Default mode when enabled: {tools:?}"
+    );
+    Ok(())
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn request_user_input_round_trip_resolves_pending() -> anyhow::Result<()> {
     request_user_input_round_trip_for_mode(ModeKind::Plan).await

--- a/codex-rs/tools/src/tool_config.rs
+++ b/codex-rs/tools/src/tool_config.rs
@@ -123,6 +123,7 @@ pub struct ToolsConfig {
     pub max_concurrent_threads_per_session: Option<usize>,
     pub wait_agent_min_timeout_ms: Option<i64>,
     pub request_user_input_available_modes: Vec<ModeKind>,
+    pub active_collaboration_mode: Option<ModeKind>,
     pub experimental_supported_tools: Vec<String>,
     pub agent_jobs_tools: bool,
     pub agent_jobs_worker_tools: bool,
@@ -261,6 +262,7 @@ impl ToolsConfig {
             max_concurrent_threads_per_session: None,
             wait_agent_min_timeout_ms: None,
             request_user_input_available_modes: request_user_input_available_modes(features),
+            active_collaboration_mode: None,
             experimental_supported_tools: model_info.experimental_supported_tools.clone(),
             agent_jobs_tools: include_agent_jobs,
             agent_jobs_worker_tools,
@@ -330,6 +332,11 @@ impl ToolsConfig {
         wait_agent_min_timeout_ms: Option<i64>,
     ) -> Self {
         self.wait_agent_min_timeout_ms = wait_agent_min_timeout_ms;
+        self
+    }
+
+    pub fn with_active_collaboration_mode(mut self, active_collaboration_mode: ModeKind) -> Self {
+        self.active_collaboration_mode = Some(active_collaboration_mode);
         self
     }
 


### PR DESCRIPTION
## Summary
- carry the active collaboration mode into tool configuration for each turn
- hide the `request_user_input` tool spec when the active mode is not allowed to call it
- keep `request_user_input` advertised in Plan mode and when Default-mode support is explicitly enabled

Fixes #44.

## Verification
- `cargo test -p codex-core request_user_input`
- `cargo test -p codex-tools`
- `$HOME/.cargo/bin/just fix -p codex-core`
- `$HOME/.cargo/bin/just fix -p codex-tools`

The regression tests cover the old listed-but-unavailable behavior by asserting `request_user_input` is absent from the advertised tool payload in Default mode, present in Plan mode, and present in Default mode when `DefaultModeRequestUserInput` is enabled.