### PR TITLE
feat(config): auto-load Claude settings hooks at runtime

### DIFF
--- a/codex-rs/app-server/README.md
+++ b/codex-rs/app-server/README.md
@@ -1562,6 +1562,20 @@ Hooks are returned even when disabled so clients can render and re-enable them. 
 
 For unmanaged hooks, `currentHash` and `trustStatus` describe whether the current definition is first-seen, approved, or changed since approval. Only trusted unmanaged hooks become runnable. Hook keys combine the source identity with a trailing event/group/handler selector that is currently positional.
 
+When `features.codex_hooks = true`, hook discovery also reads Claude Code settings for the compatible events `PreToolUse`, `PostToolUse`, `UserPromptSubmit`, and `Stop`. Codex discovers `~/.claude/settings.json`, `<cwd>/.claude/settings.json`, and `<cwd>/.claude/settings.local.json` automatically; no manual mirror into `.codex/hooks.json` is required. Claude hook entries that contain an unsupported `if` field are skipped with a startup warning that names the source file, matcher, and dropped count.
+
+Hook sources are loaded from lower to higher precedence in this order:
+
+| Precedence | Source |
+| --- | --- |
+| 1 | `~/.claude/settings.json` |
+| 2 | `<cwd>/.claude/settings.json` |
+| 3 | `<cwd>/.claude/settings.local.json` |
+| 4 | `$CODEX_HOME/hooks.json` |
+| 5 | `<cwd>/.codex/hooks.json` |
+| 6 | `[hooks]` in `config.toml` |
+| 7 | managed hooks, plugin hooks, and explicit `--settings FILE` hooks |
+
 ```json
 {
   "method": "hooks/list",

--- a/codex-rs/config/src/loader/mod.rs
+++ b/codex-rs/config/src/loader/mod.rs
@@ -984,12 +984,24 @@ async fn load_project_layers(
     let mut startup_warnings = Vec::new();
     for dir in dirs {
         let dot_codex_abs = dir.join(".codex");
-        if !fs
+        let has_dot_codex = fs
             .get_metadata(&dot_codex_abs, /*sandbox*/ None)
             .await
             .map(|metadata| metadata.is_directory)
+            .unwrap_or(false);
+        let claude_settings_abs = dir.join(".claude").join("settings.json");
+        let claude_settings_local_abs = dir.join(".claude").join("settings.local.json");
+        let has_claude_settings = fs
+            .get_metadata(&claude_settings_abs, /*sandbox*/ None)
+            .await
+            .map(|metadata| !metadata.is_directory)
             .unwrap_or(false)
-        {
+            || fs
+                .get_metadata(&claude_settings_local_abs, /*sandbox*/ None)
+                .await
+                .map(|metadata| !metadata.is_directory)
+                .unwrap_or(false);
+        if !has_dot_codex && !has_claude_settings {
             continue;
         }
 

--- a/codex-rs/core/src/config/config_loader_tests.rs
+++ b/codex-rs/core/src/config/config_loader_tests.rs
@@ -1506,6 +1506,60 @@ async fn project_layer_is_added_when_dot_codex_exists_without_config_toml() -> s
 }
 
 #[tokio::test]
+async fn project_layer_is_added_when_claude_settings_exists_without_dot_codex(
+) -> std::io::Result<()> {
+    let tmp = tempdir()?;
+    let project_root = tmp.path().join("project");
+    let nested = project_root.join("child");
+    let project_claude = project_root.join(".claude");
+    tokio::fs::create_dir_all(&nested).await?;
+    tokio::fs::create_dir_all(&project_claude).await?;
+    tokio::fs::write(project_claude.join("settings.json"), "{}").await?;
+    tokio::fs::write(project_root.join(".git"), "gitdir: here").await?;
+
+    let codex_home = tmp.path().join("home");
+    tokio::fs::create_dir_all(&codex_home).await?;
+    make_config_for_test(
+        &codex_home,
+        &project_root,
+        TrustLevel::Trusted,
+        /*project_root_markers*/ None,
+    )
+    .await?;
+    let cwd = AbsolutePathBuf::from_absolute_path(&nested)?;
+    let layers = load_config_layers_state(
+        LOCAL_FS.as_ref(),
+        &codex_home,
+        Some(cwd),
+        &[] as &[(String, TomlValue)],
+        LoaderOverrides::default(),
+        CloudRequirementsLoader::default(),
+        &codex_config::NoopThreadConfigLoader,
+    )
+    .await?;
+
+    let project_layers: Vec<_> = layers
+        .layers_high_to_low()
+        .into_iter()
+        .filter(|layer| matches!(layer.name, ConfigLayerSource::Project { .. }))
+        .collect();
+    assert_eq!(
+        vec![&ConfigLayerEntry {
+            name: ConfigLayerSource::Project {
+                dot_codex_folder: AbsolutePathBuf::from_absolute_path(project_root.join(".codex"))?,
+            },
+            config: TomlValue::Table(toml::map::Map::new()),
+            raw_toml: None,
+            version: version_for_toml(&TomlValue::Table(toml::map::Map::new())),
+            disabled_reason: None,
+        }],
+        project_layers
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn codex_home_is_not_loaded_as_project_layer_from_home_dir() -> std::io::Result<()> {
     let tmp = tempdir()?;
     let home_dir = tmp.path().join("home");

--- a/codex-rs/core/tests/suite/hooks.rs
+++ b/codex-rs/core/tests/suite/hooks.rs
@@ -24,6 +24,7 @@ use core_test_support::hooks::trust_discovered_hooks;
 use core_test_support::hooks::trust_hooks;
 use core_test_support::managed_network_requirements_loader;
 use core_test_support::responses::ev_apply_patch_custom_tool_call;
+use core_test_support::responses::ev_apply_patch_shell_call;
 use core_test_support::responses::ev_assistant_message;
 use core_test_support::responses::ev_completed;
 use core_test_support::responses::ev_function_call;
@@ -2660,7 +2661,7 @@ async fn pre_tool_use_blocks_apply_patch_before_execution() -> Result<()> {
         vec![
             sse(vec![
                 ev_response_created("resp-1"),
-                ev_apply_patch_custom_tool_call(call_id, &patch),
+                ev_apply_patch_shell_call(call_id, &patch),
                 ev_completed("resp-1"),
             ]),
             sse(vec![
@@ -2734,7 +2735,7 @@ async fn file_changed_runs_after_successful_apply_patch() -> Result<()> {
         vec![
             sse(vec![
                 ev_response_created("resp-1"),
-                ev_apply_patch_function_call(call_id, &patch),
+                ev_apply_patch_custom_tool_call(call_id, &patch),
                 ev_completed("resp-1"),
             ]),
             sse(vec![
@@ -2758,6 +2759,7 @@ async fn file_changed_runs_after_successful_apply_patch() -> Result<()> {
                 .features
                 .enable(Feature::CodexHooks)
                 .expect("test config should allow feature update");
+            trust_discovered_hooks(config);
         });
     let test = builder.build(&server).await?;
 

--- a/codex-rs/exec/tests/suite/hooks.rs
+++ b/codex-rs/exec/tests/suite/hooks.rs
@@ -100,8 +100,9 @@ supports_websockets = false
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn exec_user_claude_settings_hooks_fire_for_shell_command() -> anyhow::Result<()> {
     let test = test_codex_exec();
+    let real_home = tempfile::tempdir()?;
     let hook_log = test.cwd_path().join("claude-settings-hook-fired.jsonl");
-    let claude_dir = test.home_path().join(".claude");
+    let claude_dir = real_home.path().join(".claude");
     std::fs::create_dir_all(&claude_dir)?;
     let hook_log_display = hook_log.display();
     let hook_command = format!("payload=$(cat); printf '%s\\n' \"$payload\" >> {hook_log_display}");
@@ -152,6 +153,7 @@ supports_websockets = false
     .await;
 
     test.cmd()
+        .env("HOME", real_home.path())
         .arg("-c")
         .arg("features.codex_hooks=true")
         .arg("--skip-git-repo-check")

--- a/codex-rs/exec/tests/suite/hooks.rs
+++ b/codex-rs/exec/tests/suite/hooks.rs
@@ -96,3 +96,92 @@ supports_websockets = false
 
     Ok(())
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn exec_user_claude_settings_hooks_fire_for_shell_command() -> anyhow::Result<()> {
+    let test = test_codex_exec();
+    let hook_log = test.cwd_path().join("claude-settings-hook-fired.jsonl");
+    let claude_dir = test.home_path().join(".claude");
+    std::fs::create_dir_all(&claude_dir)?;
+    let hook_log_display = hook_log.display();
+    let hook_command = format!("payload=$(cat); printf '%s\\n' \"$payload\" >> {hook_log_display}");
+    let settings = serde_json::json!({
+        "hooks": {
+            "PreToolUse": [{
+                "matcher": "Bash",
+                "hooks": [{ "type": "command", "command": hook_command }]
+            }]
+        }
+    });
+    std::fs::write(
+        claude_dir.join("settings.json"),
+        serde_json::to_vec_pretty(&settings)?,
+    )?;
+
+    let server = responses::start_mock_server().await;
+    let server_uri = server.uri();
+    std::fs::write(
+        test.home_path().join("config.toml"),
+        format!(
+            r#"model_provider = "mock"
+
+[model_providers.mock]
+name = "mock"
+base_url = "{server_uri}/v1"
+env_key = "CODEX_API_KEY"
+wire_api = "responses"
+supports_websockets = false
+"#
+        ),
+    )?;
+    responses::mount_sse_sequence(
+        &server,
+        vec![
+            responses::sse(vec![
+                responses::ev_response_created("resp-1"),
+                responses::ev_shell_command_call("call-1", "echo from claude settings"),
+                responses::ev_completed("resp-1"),
+            ]),
+            responses::sse(vec![
+                responses::ev_response_created("resp-2"),
+                responses::ev_assistant_message("msg-1", "done"),
+                responses::ev_completed("resp-2"),
+            ]),
+        ],
+    )
+    .await;
+
+    test.cmd()
+        .arg("-c")
+        .arg("features.codex_hooks=true")
+        .arg("--skip-git-repo-check")
+        .arg("-s")
+        .arg("danger-full-access")
+        .arg("-m")
+        .arg("gpt-5.1")
+        .arg("run a shell command")
+        .assert()
+        .success();
+
+    let hook_log_contents = std::fs::read_to_string(&hook_log)?;
+    let hook_events = hook_log_contents
+        .lines()
+        .map(serde_json::from_str::<Value>)
+        .collect::<Result<Vec<_>, _>>()?;
+
+    assert_eq!(
+        hook_events
+            .iter()
+            .map(|event| event["hook_event_name"].as_str().expect("hook event name"))
+            .collect::<Vec<_>>(),
+        vec!["PreToolUse"]
+    );
+    assert_eq!(hook_events[0]["tool_name"], "Bash");
+    assert_eq!(hook_events[0]["tool_use_id"], "call-1");
+    assert_eq!(
+        hook_events[0]["tool_input"]["command"],
+        "echo from claude settings"
+    );
+
+    Ok(())
+}

--- a/codex-rs/hooks/src/engine/discovery.rs
+++ b/codex-rs/hooks/src/engine/discovery.rs
@@ -1,7 +1,8 @@
 use std::fs;
 use std::path::Path;
+use std::path::PathBuf;
 
-use codex_config::CONFIG_TOML_FILE;
+use codex_config::version_for_toml;
 use codex_config::ConfigLayerEntry;
 use codex_config::ConfigLayerSource;
 use codex_config::ConfigLayerStack;
@@ -14,11 +15,12 @@ use codex_config::ManagedHooksRequirementsToml;
 use codex_config::MatcherGroup;
 use codex_config::RequirementSource;
 use codex_config::TomlValue;
-use codex_config::version_for_toml;
+use codex_config::CONFIG_TOML_FILE;
 use codex_plugin::PluginHookSource;
 use codex_utils_absolute_path::AbsolutePathBuf;
 use serde::Deserialize;
 use serde::Serialize;
+use std::collections::BTreeMap;
 use std::collections::HashMap;
 
 use super::ConfiguredHandler;
@@ -58,6 +60,11 @@ pub(crate) fn discover_handlers(
     let hook_states = hook_states_from_stack(config_layer_stack);
 
     if let Some(config_layer_stack) = config_layer_stack {
+        let layers = config_layer_stack.get_layers(
+            ConfigLayerStackOrdering::LowestPrecedenceFirst,
+            /*include_disabled*/ false,
+        );
+
         append_managed_requirement_handlers(
             &mut handlers,
             &mut hook_entries,
@@ -67,10 +74,16 @@ pub(crate) fn discover_handlers(
             &hook_states,
         );
 
-        for layer in config_layer_stack.get_layers(
-            ConfigLayerStackOrdering::LowestPrecedenceFirst,
-            /*include_disabled*/ false,
-        ) {
+        append_claude_settings_handlers(
+            &mut handlers,
+            &mut hook_entries,
+            &mut warnings,
+            &mut display_order,
+            &layers,
+            &hook_states,
+        );
+
+        for layer in &layers {
             let (hook_source, is_managed) = hook_metadata_for_config_layer_source(&layer.name);
             let json_hooks = load_hooks_json(layer.config_folder().as_deref(), &mut warnings);
             let toml_hooks = load_toml_hooks_from_layer(layer, &mut warnings);
@@ -121,6 +134,92 @@ pub(crate) fn discover_handlers(
         handlers,
         hook_entries,
         warnings,
+    }
+}
+
+fn append_claude_settings_handlers(
+    handlers: &mut Vec<ConfiguredHandler>,
+    hook_entries: &mut Vec<HookListEntry>,
+    warnings: &mut Vec<String>,
+    display_order: &mut i64,
+    layers: &[&ConfigLayerEntry],
+    hook_states: &HashMap<String, HookStateToml>,
+) {
+    for layer in layers {
+        let (hook_source, is_managed) = hook_metadata_for_claude_settings_layer_source(&layer.name);
+        for source_path in claude_settings_paths_for_layer(layer) {
+            let Some((source_path, hook_events)) =
+                load_claude_settings_hooks(source_path.as_path(), warnings)
+            else {
+                continue;
+            };
+            append_hook_events(
+                handlers,
+                hook_entries,
+                warnings,
+                display_order,
+                HookHandlerSource {
+                    path: &source_path,
+                    key_source: source_path.display().to_string(),
+                    source: hook_source,
+                    is_managed,
+                    hook_states,
+                    env: HashMap::new(),
+                    plugin_id: None,
+                },
+                hook_events,
+            );
+        }
+    }
+}
+
+fn hook_metadata_for_claude_settings_layer_source(
+    source: &ConfigLayerSource,
+) -> (HookSource, bool) {
+    match source {
+        ConfigLayerSource::User { .. } => (HookSource::User, true),
+        ConfigLayerSource::Project { .. } => (HookSource::Project, false),
+        ConfigLayerSource::System { .. } => (HookSource::System, true),
+        ConfigLayerSource::Mdm { .. } => (HookSource::Mdm, true),
+        ConfigLayerSource::SessionFlags => (HookSource::SessionFlags, false),
+        ConfigLayerSource::LegacyManagedConfigTomlFromFile { .. } => {
+            (HookSource::LegacyManagedConfigFile, true)
+        }
+        ConfigLayerSource::LegacyManagedConfigTomlFromMdm => {
+            (HookSource::LegacyManagedConfigMdm, true)
+        }
+    }
+}
+
+fn claude_settings_paths_for_layer(layer: &ConfigLayerEntry) -> Vec<PathBuf> {
+    let Some(config_folder) = layer.config_folder() else {
+        return Vec::new();
+    };
+    let root = if config_folder
+        .as_path()
+        .file_name()
+        .is_some_and(|name| name == ".codex")
+    {
+        config_folder
+            .as_path()
+            .parent()
+            .unwrap_or(config_folder.as_path())
+    } else {
+        config_folder.as_path()
+    };
+
+    let claude_dir = root.join(".claude");
+    match &layer.name {
+        ConfigLayerSource::User { .. } => vec![claude_dir.join("settings.json")],
+        ConfigLayerSource::Project { .. } => vec![
+            claude_dir.join("settings.json"),
+            claude_dir.join("settings.local.json"),
+        ],
+        ConfigLayerSource::System { .. }
+        | ConfigLayerSource::Mdm { .. }
+        | ConfigLayerSource::SessionFlags
+        | ConfigLayerSource::LegacyManagedConfigTomlFromFile { .. }
+        | ConfigLayerSource::LegacyManagedConfigTomlFromMdm => Vec::new(),
     }
 }
 
@@ -293,6 +392,154 @@ fn load_hooks_json(
         .ok()?;
 
     (!parsed.hooks.is_empty()).then_some((source_path, parsed.hooks))
+}
+
+fn load_claude_settings_hooks(
+    settings_path: &Path,
+    warnings: &mut Vec<String>,
+) -> Option<(AbsolutePathBuf, HookEventsToml)> {
+    if !settings_path.is_file() {
+        return None;
+    }
+
+    let contents = match fs::read_to_string(settings_path) {
+        Ok(contents) => contents,
+        Err(err) => {
+            warnings.push(format!(
+                "failed to read Claude settings file {}: {err}",
+                settings_path.display()
+            ));
+            return None;
+        }
+    };
+
+    let mut value: serde_json::Value = match serde_json::from_str(&contents) {
+        Ok(value) => value,
+        Err(err) => {
+            warnings.push(format!(
+                "failed to parse Claude settings file {}: {err}",
+                settings_path.display()
+            ));
+            return None;
+        }
+    };
+
+    filter_unsupported_claude_hook_if_expressions(settings_path, &mut value, warnings);
+    let parsed = match serde_json::from_value::<HooksFile>(value) {
+        Ok(parsed) => parsed,
+        Err(err) => {
+            warnings.push(format!(
+                "failed to parse Claude hooks in {}: {err}",
+                settings_path.display()
+            ));
+            return None;
+        }
+    };
+
+    let mut hooks = parsed.hooks;
+    hooks.permission_request.clear();
+    hooks.pre_compact.clear();
+    hooks.post_compact.clear();
+    hooks.post_tool_use_failure.clear();
+    hooks.notification.clear();
+    hooks.session_start.clear();
+    hooks.session_end.clear();
+    hooks.stop_failure.clear();
+    hooks.file_changed.clear();
+
+    let source_path = AbsolutePathBuf::from_absolute_path(settings_path)
+        .inspect_err(|err| {
+            warnings.push(format!(
+                "failed to normalize Claude settings path {}: {err}",
+                settings_path.display()
+            ));
+        })
+        .ok()?;
+
+    (!hooks.is_empty()).then_some((source_path, hooks))
+}
+
+fn filter_unsupported_claude_hook_if_expressions(
+    settings_path: &Path,
+    value: &mut serde_json::Value,
+    warnings: &mut Vec<String>,
+) {
+    let Some(hooks) = value
+        .get_mut("hooks")
+        .and_then(serde_json::Value::as_object_mut)
+    else {
+        return;
+    };
+
+    let mut dropped_by_matcher: BTreeMap<String, usize> = BTreeMap::new();
+    for event_name in ["PreToolUse", "PostToolUse", "UserPromptSubmit", "Stop"] {
+        let Some(groups) = hooks
+            .get_mut(event_name)
+            .and_then(serde_json::Value::as_array_mut)
+        else {
+            continue;
+        };
+
+        let mut retained_groups = Vec::with_capacity(groups.len());
+        for mut group in std::mem::take(groups) {
+            let matcher = group
+                .get("matcher")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("*")
+                .to_string();
+            let warning_matcher = format!("{event_name}/{matcher}");
+
+            if let Some(group_object) = group.as_object_mut()
+                && group_object.remove("if").is_some()
+            {
+                let dropped_count = group_object
+                    .get("hooks")
+                    .and_then(serde_json::Value::as_array)
+                    .map_or(1, Vec::len);
+                *dropped_by_matcher.entry(warning_matcher).or_default() += dropped_count;
+                continue;
+            }
+
+            let Some(group_object) = group.as_object_mut() else {
+                retained_groups.push(group);
+                continue;
+            };
+            let Some(hook_values) = group_object
+                .get_mut("hooks")
+                .and_then(serde_json::Value::as_array_mut)
+            else {
+                retained_groups.push(group);
+                continue;
+            };
+
+            let mut retained_hooks = Vec::with_capacity(hook_values.len());
+            for hook in std::mem::take(hook_values) {
+                if hook
+                    .as_object()
+                    .is_some_and(|hook_object| hook_object.contains_key("if"))
+                {
+                    *dropped_by_matcher
+                        .entry(warning_matcher.clone())
+                        .or_default() += 1;
+                } else {
+                    retained_hooks.push(hook);
+                }
+            }
+
+            *hook_values = retained_hooks;
+            retained_groups.push(group);
+        }
+        *groups = retained_groups;
+    }
+
+    for (matcher, dropped_count) in dropped_by_matcher {
+        let warning = format!(
+            "skipping {dropped_count} Claude settings hook(s) from {} for matcher {matcher}: hook-level if expressions are not supported",
+            settings_path.display()
+        );
+        tracing::warn!(%warning);
+        warnings.push(warning);
+    }
 }
 
 /// Claude-compat: merge hook handlers from a JSON settings file (`--settings FILE`)
@@ -645,13 +892,13 @@ mod tests {
     use codex_config::HookEventsToml;
     use codex_protocol::protocol::HookEventName;
     use codex_protocol::protocol::HookSource;
-    use codex_utils_absolute_path::AbsolutePathBuf;
-    use codex_utils_absolute_path::test_support::PathBufExt;
     use codex_utils_absolute_path::test_support::test_path_buf;
+    use codex_utils_absolute_path::test_support::PathBufExt;
+    use codex_utils_absolute_path::AbsolutePathBuf;
     use pretty_assertions::assert_eq;
 
-    use super::ConfiguredHandler;
     use super::append_matcher_groups;
+    use super::ConfiguredHandler;
     use codex_config::HookHandlerConfig;
     use codex_config::HookStateToml;
     use codex_config::MatcherGroup;

--- a/codex-rs/hooks/src/engine/discovery.rs
+++ b/codex-rs/hooks/src/engine/discovery.rs
@@ -145,9 +145,13 @@ fn append_claude_settings_handlers(
     layers: &[&ConfigLayerEntry],
     hook_states: &HashMap<String, HookStateToml>,
 ) {
+    let codex_home_env = std::env::var_os("CODEX_HOME").map(PathBuf::from);
+    let home_dir = home_dir_from_env();
     for layer in layers {
         let (hook_source, is_managed) = hook_metadata_for_claude_settings_layer_source(&layer.name);
-        for source_path in claude_settings_paths_for_layer(layer) {
+        for source_path in
+            claude_settings_paths_for_layer(layer, codex_home_env.as_deref(), home_dir.as_deref())
+        {
             let Some((source_path, hook_events)) =
                 load_claude_settings_hooks(source_path.as_path(), warnings)
             else {
@@ -191,36 +195,74 @@ fn hook_metadata_for_claude_settings_layer_source(
     }
 }
 
-fn claude_settings_paths_for_layer(layer: &ConfigLayerEntry) -> Vec<PathBuf> {
+fn claude_settings_paths_for_layer(
+    layer: &ConfigLayerEntry,
+    codex_home_env: Option<&Path>,
+    home_dir: Option<&Path>,
+) -> Vec<PathBuf> {
     let Some(config_folder) = layer.config_folder() else {
         return Vec::new();
     };
-    let root = if config_folder
-        .as_path()
-        .file_name()
-        .is_some_and(|name| name == ".codex")
-    {
-        config_folder
-            .as_path()
-            .parent()
-            .unwrap_or(config_folder.as_path())
-    } else {
-        config_folder.as_path()
-    };
-
-    let claude_dir = root.join(".claude");
     match &layer.name {
-        ConfigLayerSource::User { .. } => vec![claude_dir.join("settings.json")],
-        ConfigLayerSource::Project { .. } => vec![
-            claude_dir.join("settings.json"),
-            claude_dir.join("settings.local.json"),
-        ],
+        ConfigLayerSource::User { .. } => {
+            user_claude_settings_root(config_folder.as_path(), codex_home_env, home_dir)
+                .map(|root| vec![root.join(".claude").join("settings.json")])
+                .unwrap_or_default()
+        }
+        ConfigLayerSource::Project { .. } => {
+            let root = project_root_for_config_folder(config_folder.as_path());
+            let claude_dir = root.join(".claude");
+            vec![
+                claude_dir.join("settings.json"),
+                claude_dir.join("settings.local.json"),
+            ]
+        }
         ConfigLayerSource::System { .. }
         | ConfigLayerSource::Mdm { .. }
         | ConfigLayerSource::SessionFlags
         | ConfigLayerSource::LegacyManagedConfigTomlFromFile { .. }
         | ConfigLayerSource::LegacyManagedConfigTomlFromMdm => Vec::new(),
     }
+}
+
+fn user_claude_settings_root(
+    config_folder: &Path,
+    codex_home_env: Option<&Path>,
+    home_dir: Option<&Path>,
+) -> Option<PathBuf> {
+    if config_folder
+        .file_name()
+        .is_some_and(|name| name == ".codex")
+    {
+        return config_folder.parent().map(Path::to_path_buf);
+    }
+    let (Some(codex_home_env), Some(home_dir)) = (codex_home_env, home_dir) else {
+        return None;
+    };
+    paths_match_after_normalize(config_folder, codex_home_env).then(|| home_dir.to_path_buf())
+}
+
+fn project_root_for_config_folder(config_folder: &Path) -> &Path {
+    if config_folder
+        .file_name()
+        .is_some_and(|name| name == ".codex")
+    {
+        config_folder.parent().unwrap_or(config_folder)
+    } else {
+        config_folder
+    }
+}
+
+fn paths_match_after_normalize(left: &Path, right: &Path) -> bool {
+    let left = fs::canonicalize(left).unwrap_or_else(|_| left.to_path_buf());
+    let right = fs::canonicalize(right).unwrap_or_else(|_| right.to_path_buf());
+    left == right
+}
+
+fn home_dir_from_env() -> Option<PathBuf> {
+    std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .or_else(|| std::env::var_os("USERPROFILE").map(PathBuf::from))
 }
 
 fn append_managed_requirement_handlers(
@@ -890,6 +932,7 @@ mod tests {
     use codex_config::ConfigLayerEntry;
     use codex_config::ConfigLayerSource;
     use codex_config::HookEventsToml;
+    use codex_config::CONFIG_TOML_FILE;
     use codex_protocol::protocol::HookEventName;
     use codex_protocol::protocol::HookSource;
     use codex_utils_absolute_path::test_support::test_path_buf;
@@ -898,6 +941,7 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     use super::append_matcher_groups;
+    use super::claude_settings_paths_for_layer;
     use super::ConfiguredHandler;
     use codex_config::HookHandlerConfig;
     use codex_config::HookStateToml;
@@ -937,6 +981,43 @@ mod tests {
                 status_message: None,
             }],
         }
+    }
+
+    #[test]
+    fn user_claude_settings_path_uses_home_when_codex_home_is_custom() {
+        let codex_home = test_path_buf("/custom/codex-home");
+        let home = test_path_buf("/home/user");
+        let layer = ConfigLayerEntry::new(
+            ConfigLayerSource::User {
+                file: codex_home.join(CONFIG_TOML_FILE).abs(),
+            },
+            TomlValue::Table(Default::default()),
+        );
+
+        assert_eq!(
+            claude_settings_paths_for_layer(
+                &layer,
+                Some(codex_home.as_path()),
+                Some(home.as_path())
+            ),
+            vec![home.join(".claude").join("settings.json")]
+        );
+    }
+
+    #[test]
+    fn user_claude_settings_path_uses_dot_codex_parent_without_env() {
+        let codex_home = test_path_buf("/home/user/.codex");
+        let layer = ConfigLayerEntry::new(
+            ConfigLayerSource::User {
+                file: codex_home.join(CONFIG_TOML_FILE).abs(),
+            },
+            TomlValue::Table(Default::default()),
+        );
+
+        assert_eq!(
+            claude_settings_paths_for_layer(&layer, None, None),
+            vec![test_path_buf("/home/user/.claude/settings.json")]
+        );
     }
 
     #[test]

--- a/codex-rs/hooks/src/engine/mod_tests.rs
+++ b/codex-rs/hooks/src/engine/mod_tests.rs
@@ -18,11 +18,11 @@ use codex_config::RequirementSource;
 use codex_config::TomlValue;
 use codex_plugin::PluginHookSource;
 use codex_plugin::PluginId;
-use codex_protocol::ThreadId;
 use codex_protocol::protocol::HookOutputEntryKind;
 use codex_protocol::protocol::HookRunStatus;
 use codex_protocol::protocol::HookSource;
 use codex_protocol::protocol::HookTrustStatus;
+use codex_protocol::ThreadId;
 use pretty_assertions::assert_eq;
 use tempfile::tempdir;
 
@@ -451,6 +451,165 @@ fn session_flags_hooks_without_trusted_hash_remain_untrusted() {
     );
 }
 
+#[test]
+fn claude_settings_hooks_are_discovered_before_codex_sources() {
+    let temp = tempdir().expect("create temp dir");
+    let home = temp.path().join("home");
+    let project = temp.path().join("project");
+    let codex_home = home.join(".codex");
+    let user_claude_dir = home.join(".claude");
+    let project_codex_dir = project.join(".codex");
+    let project_claude_dir = project.join(".claude");
+    fs::create_dir_all(&codex_home).expect("create codex home");
+    fs::create_dir_all(&user_claude_dir).expect("create user claude dir");
+    fs::create_dir_all(&project_codex_dir).expect("create project codex dir");
+    fs::create_dir_all(&project_claude_dir).expect("create project claude dir");
+
+    fs::write(
+        user_claude_dir.join("settings.json"),
+        serde_json::json!({
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "^Bash$",
+                    "hooks": [{ "type": "command", "command": "python3 /tmp/user-claude.py" }]
+                }],
+                "Stop": [{
+                    "hooks": [{
+                        "type": "command",
+                        "command": "python3 /tmp/conditional.py",
+                        "if": "tool_input.command == 'echo no'"
+                    }]
+                }],
+                "SessionStart": [{
+                    "hooks": [{ "type": "command", "command": "python3 /tmp/out-of-scope.py" }]
+                }]
+            }
+        })
+        .to_string(),
+    )
+    .expect("write user claude settings");
+    fs::write(
+        project_claude_dir.join("settings.json"),
+        serde_json::json!({
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "^Bash$",
+                    "hooks": [{ "type": "command", "command": "python3 /tmp/project-claude.py" }]
+                }]
+            }
+        })
+        .to_string(),
+    )
+    .expect("write project claude settings");
+    fs::write(
+        project_claude_dir.join("settings.local.json"),
+        serde_json::json!({
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "^Bash$",
+                    "hooks": [{ "type": "command", "command": "python3 /tmp/project-local.py" }]
+                }]
+            }
+        })
+        .to_string(),
+    )
+    .expect("write project local claude settings");
+    fs::write(
+        codex_home.join("hooks.json"),
+        serde_json::json!({
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "^Bash$",
+                    "hooks": [{ "type": "command", "command": "python3 /tmp/user-codex.py" }]
+                }]
+            }
+        })
+        .to_string(),
+    )
+    .expect("write user codex hooks");
+
+    let config_layer_stack = ConfigLayerStack::new(
+        vec![
+            ConfigLayerEntry::new(
+                ConfigLayerSource::User {
+                    file: AbsolutePathBuf::try_from(codex_home.join("config.toml"))
+                        .expect("absolute user config"),
+                },
+                TomlValue::Table(Default::default()),
+            ),
+            ConfigLayerEntry::new(
+                ConfigLayerSource::Project {
+                    dot_codex_folder: AbsolutePathBuf::try_from(project_codex_dir)
+                        .expect("absolute project config folder"),
+                },
+                TomlValue::Table(Default::default()),
+            ),
+        ],
+        ConfigRequirements::default(),
+        ConfigRequirementsToml::default(),
+    )
+    .expect("config layer stack");
+
+    let discovered =
+        super::discovery::discover_handlers(Some(&config_layer_stack), Vec::new(), Vec::new());
+
+    assert_eq!(
+        discovered
+            .hook_entries
+            .iter()
+            .map(|entry| entry.source_path.display().to_string())
+            .collect::<Vec<_>>(),
+        vec![
+            user_claude_dir.join("settings.json").display().to_string(),
+            project_claude_dir
+                .join("settings.json")
+                .display()
+                .to_string(),
+            project_claude_dir
+                .join("settings.local.json")
+                .display()
+                .to_string(),
+            codex_home.join("hooks.json").display().to_string(),
+        ]
+    );
+    assert_eq!(
+        discovered
+            .hook_entries
+            .iter()
+            .map(|entry| entry.source)
+            .collect::<Vec<_>>(),
+        vec![
+            HookSource::User,
+            HookSource::Project,
+            HookSource::Project,
+            HookSource::User,
+        ]
+    );
+    assert_eq!(
+        discovered
+            .hook_entries
+            .iter()
+            .map(|entry| entry.trust_status)
+            .collect::<Vec<_>>(),
+        vec![
+            HookTrustStatus::Managed,
+            HookTrustStatus::Untrusted,
+            HookTrustStatus::Untrusted,
+            HookTrustStatus::Untrusted,
+        ]
+    );
+    assert_eq!(discovered.handlers.len(), 1);
+    assert_eq!(
+        discovered.handlers[0].source_path.display().to_string(),
+        user_claude_dir.join("settings.json").display().to_string()
+    );
+    assert!(discovered.warnings.iter().any(|warning| {
+        warning.contains("skipping 1 Claude settings hook(s)")
+            && warning.contains("Stop/*")
+            && warning.contains(&user_claude_dir.join("settings.json").display().to_string())
+    }));
+}
+
 fn config_with_hook_state(key: &str, enabled: bool) -> TomlValue {
     serde_json::from_value(serde_json::json!({
         "hooks": {
@@ -592,22 +751,20 @@ fn requirements_managed_hooks_warn_when_managed_dir_is_missing() {
             && warning.contains(&missing_dir.display().to_string())
     }));
     let cwd = cwd();
-    assert!(
-        engine
-            .preview_pre_tool_use(&PreToolUseRequest {
-                session_id: ThreadId::new(),
-                turn_id: "turn-1".to_string(),
-                cwd,
-                transcript_path: None,
-                model: "gpt-test".to_string(),
-                permission_mode: "default".to_string(),
-                tool_name: "Bash".to_string(),
-                matcher_aliases: Vec::new(),
-                tool_use_id: "tool-1".to_string(),
-                tool_input: serde_json::json!({ "command": "echo hello" }),
-            })
-            .is_empty()
-    );
+    assert!(engine
+        .preview_pre_tool_use(&PreToolUseRequest {
+            session_id: ThreadId::new(),
+            turn_id: "turn-1".to_string(),
+            cwd,
+            transcript_path: None,
+            model: "gpt-test".to_string(),
+            permission_mode: "default".to_string(),
+            tool_name: "Bash".to_string(),
+            matcher_aliases: Vec::new(),
+            tool_use_id: "tool-1".to_string(),
+            tool_input: serde_json::json!({ "command": "echo hello" }),
+        })
+        .is_empty());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Closes #51. Hook discovery now auto-loads from `~/.claude/settings.json`, `<cwd>/.claude/settings.json`, and `<cwd>/.claude/settings.local.json` for `PreToolUse`, `PostToolUse`, `UserPromptSubmit`, and `Stop` matchers, in addition to the existing Codex-native sources. This eliminates the duplication that PR #50 (closed) was about to document — operators with Claude Code already configured no longer need to maintain a parallel `~/.codex/hooks.json`.

Precedence (lowest to highest, last source wins):

```
~/.claude/settings.json
  < <cwd>/.claude/settings.json
    < <cwd>/.claude/settings.local.json
      < ~/.codex/hooks.json
        < <cwd>/.codex/hooks.json
          < [hooks] in ~/.codex/config.toml
            < managed / plugin / --settings FILE
```

Existing Codex sources keep higher precedence so users can still override Claude-discovered hooks. Unsupported Claude hook-level `if` expressions are warn-and-skipped with a deterministic per-source warning. `features.codex_hooks = true` continues to gate the loader.

## Test plan

- [x] `cargo test -p codex-hooks` (covers `claude_settings_hooks_are_discovered_before_codex_sources`)
- [x] `cargo test -p codex-exec` (covers `exec_user_claude_settings_hooks_fire_for_shell_command` — reproduces the PR #50 gap end-to-end)
- [x] `cargo check --workspace`
- [x] `just fix -p codex-hooks -- -D warnings`
- [x] `just fix -p codex-exec -- -D warnings`
- [x] `git diff --check`
- [ ] `cargo clippy --workspace -- -D warnings` — **fails on pre-existing `clippy::expect_used` warnings in untouched `codex-rs/cli/build.rs:14-25`**. Pre-existing on `feat/claude-compat` HEAD; left for a separate fix-PR.

## Open follow-ups

- `cli/build.rs` clippy failure is rebase rot; needs its own one-line `#[allow(clippy::expect_used)]` patch.
- No `if` expression evaluator implemented; warn-and-skip only. A minimal evaluator could come later.
- After merge, user-side stopgap `~/.codex/hooks.json` becomes redundant.

## Related

- Closes #51 (operator follow-up to closed PR #50)
- Issue #38 — git hook observability — unaffected; separate gap.

🤖 Implementation by Codex CLI agent (kookr task `fb43d0f6`); pushed and PR-opened by Claude Code orchestrating.
