### PR TITLE
feat(hooks): support Claude Bash if conditions

### DIFF
--- a/codex-rs/hooks/src/engine/discovery.rs
+++ b/codex-rs/hooks/src/engine/discovery.rs
@@ -23,11 +23,14 @@ use serde::Serialize;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 
+use super::dispatcher::encode_claude_conditional_matcher;
+use super::dispatcher::ClaudeHookCondition;
 use super::ConfiguredHandler;
 use super::HookListEntry;
 use crate::config_rules::hook_states_from_stack;
 use crate::events::common::matcher_pattern_for_event;
 use crate::events::common::validate_matcher_pattern;
+use codex_protocol::protocol::HookEventName;
 use codex_protocol::protocol::HookHandlerType;
 use codex_protocol::protocol::HookSource;
 use codex_protocol::protocol::HookTrustStatus;
@@ -46,6 +49,15 @@ struct HookHandlerSource<'a> {
     hook_states: &'a HashMap<String, HookStateToml>,
     env: HashMap<String, String>,
     plugin_id: Option<String>,
+    claude_conditions: Vec<ClaudeHookConditionByPosition>,
+}
+
+#[derive(Clone)]
+struct ClaudeHookConditionByPosition {
+    event_name: HookEventName,
+    group_index: usize,
+    handler_index: usize,
+    conditions: Vec<ClaudeHookCondition>,
 }
 
 pub(crate) fn discover_handlers(
@@ -114,6 +126,7 @@ pub(crate) fn discover_handlers(
                         hook_states: &hook_states,
                         env: HashMap::new(),
                         plugin_id: None,
+                        claude_conditions: Vec::new(),
                     },
                     hook_events,
                 );
@@ -152,7 +165,7 @@ fn append_claude_settings_handlers(
         for source_path in
             claude_settings_paths_for_layer(layer, codex_home_env.as_deref(), home_dir.as_deref())
         {
-            let Some((source_path, hook_events)) =
+            let Some((source_path, hook_events, claude_conditions)) =
                 load_claude_settings_hooks(source_path.as_path(), warnings)
             else {
                 continue;
@@ -170,6 +183,7 @@ fn append_claude_settings_handlers(
                     hook_states,
                     env: HashMap::new(),
                     plugin_id: None,
+                    claude_conditions,
                 },
                 hook_events,
             );
@@ -294,6 +308,7 @@ fn append_managed_requirement_handlers(
             hook_states,
             env: HashMap::new(),
             plugin_id: None,
+            claude_conditions: Vec::new(),
         },
         managed_hooks.get().hooks.clone(),
     );
@@ -342,6 +357,7 @@ fn append_plugin_hook_sources(
                 hook_states,
                 env,
                 plugin_id: Some(plugin_id),
+                claude_conditions: Vec::new(),
             },
             hooks,
         );
@@ -439,7 +455,11 @@ fn load_hooks_json(
 fn load_claude_settings_hooks(
     settings_path: &Path,
     warnings: &mut Vec<String>,
-) -> Option<(AbsolutePathBuf, HookEventsToml)> {
+) -> Option<(
+    AbsolutePathBuf,
+    HookEventsToml,
+    Vec<ClaudeHookConditionByPosition>,
+)> {
     if !settings_path.is_file() {
         return None;
     }
@@ -466,7 +486,8 @@ fn load_claude_settings_hooks(
         }
     };
 
-    filter_unsupported_claude_hook_if_expressions(settings_path, &mut value, warnings);
+    let claude_conditions =
+        filter_unsupported_claude_hook_if_expressions(settings_path, &mut value, warnings);
     let parsed = match serde_json::from_value::<HooksFile>(value) {
         Ok(parsed) => parsed,
         Err(err) => {
@@ -498,25 +519,31 @@ fn load_claude_settings_hooks(
         })
         .ok()?;
 
-    (!hooks.is_empty()).then_some((source_path, hooks))
+    (!hooks.is_empty()).then_some((source_path, hooks, claude_conditions))
 }
 
 fn filter_unsupported_claude_hook_if_expressions(
     settings_path: &Path,
     value: &mut serde_json::Value,
     warnings: &mut Vec<String>,
-) {
+) -> Vec<ClaudeHookConditionByPosition> {
     let Some(hooks) = value
         .get_mut("hooks")
         .and_then(serde_json::Value::as_object_mut)
     else {
-        return;
+        return Vec::new();
     };
 
+    let mut conditions_by_position = Vec::new();
     let mut dropped_by_matcher: BTreeMap<String, usize> = BTreeMap::new();
-    for event_name in ["PreToolUse", "PostToolUse", "UserPromptSubmit", "Stop"] {
+    for (event_label, event_name) in [
+        ("PreToolUse", HookEventName::PreToolUse),
+        ("PostToolUse", HookEventName::PostToolUse),
+        ("UserPromptSubmit", HookEventName::UserPromptSubmit),
+        ("Stop", HookEventName::Stop),
+    ] {
         let Some(groups) = hooks
-            .get_mut(event_name)
+            .get_mut(event_label)
             .and_then(serde_json::Value::as_array_mut)
         else {
             continue;
@@ -529,22 +556,25 @@ fn filter_unsupported_claude_hook_if_expressions(
                 .and_then(serde_json::Value::as_str)
                 .unwrap_or("*")
                 .to_string();
-            let warning_matcher = format!("{event_name}/{matcher}");
-
-            if let Some(group_object) = group.as_object_mut()
-                && group_object.remove("if").is_some()
-            {
-                let dropped_count = group_object
-                    .get("hooks")
-                    .and_then(serde_json::Value::as_array)
-                    .map_or(1, Vec::len);
-                *dropped_by_matcher.entry(warning_matcher).or_default() += dropped_count;
-                continue;
-            }
+            let warning_matcher = format!("{event_label}/{matcher}");
 
             let Some(group_object) = group.as_object_mut() else {
                 retained_groups.push(group);
                 continue;
+            };
+            let group_conditions = match group_object.remove("if") {
+                Some(value) => match parse_supported_claude_if_expression(event_name, &value) {
+                    Some(condition) => vec![condition],
+                    None => {
+                        let dropped_count = group_object
+                            .get("hooks")
+                            .and_then(serde_json::Value::as_array)
+                            .map_or(1, Vec::len);
+                        *dropped_by_matcher.entry(warning_matcher).or_default() += dropped_count;
+                        continue;
+                    }
+                },
+                None => Vec::new(),
             };
             let Some(hook_values) = group_object
                 .get_mut("hooks")
@@ -554,18 +584,35 @@ fn filter_unsupported_claude_hook_if_expressions(
                 continue;
             };
 
+            let group_index = retained_groups.len();
             let mut retained_hooks = Vec::with_capacity(hook_values.len());
             for hook in std::mem::take(hook_values) {
-                if hook
-                    .as_object()
-                    .is_some_and(|hook_object| hook_object.contains_key("if"))
+                let mut hook_conditions = group_conditions.clone();
+                let mut hook = hook;
+                if let Some(hook_object) = hook.as_object_mut()
+                    && let Some(value) = hook_object.remove("if")
                 {
-                    *dropped_by_matcher
-                        .entry(warning_matcher.clone())
-                        .or_default() += 1;
-                } else {
-                    retained_hooks.push(hook);
+                    match parse_supported_claude_if_expression(event_name, &value) {
+                        Some(condition) => hook_conditions.push(condition),
+                        None => {
+                            *dropped_by_matcher
+                                .entry(warning_matcher.clone())
+                                .or_default() += 1;
+                            continue;
+                        }
+                    }
                 }
+
+                let handler_index = retained_hooks.len();
+                if !hook_conditions.is_empty() {
+                    conditions_by_position.push(ClaudeHookConditionByPosition {
+                        event_name,
+                        group_index,
+                        handler_index,
+                        conditions: hook_conditions,
+                    });
+                }
+                retained_hooks.push(hook);
             }
 
             *hook_values = retained_hooks;
@@ -582,6 +629,39 @@ fn filter_unsupported_claude_hook_if_expressions(
         tracing::warn!(%warning);
         warnings.push(warning);
     }
+    conditions_by_position
+}
+
+fn parse_supported_claude_if_expression(
+    event_name: HookEventName,
+    value: &serde_json::Value,
+) -> Option<ClaudeHookCondition> {
+    match event_name {
+        HookEventName::PreToolUse | HookEventName::PostToolUse => {}
+        HookEventName::PermissionRequest
+        | HookEventName::PreCompact
+        | HookEventName::PostCompact
+        | HookEventName::PostToolUseFailure
+        | HookEventName::Notification
+        | HookEventName::SessionStart
+        | HookEventName::SessionEnd
+        | HookEventName::UserPromptSubmit
+        | HookEventName::Stop
+        | HookEventName::StopFailure
+        | HookEventName::FileChanged => return None,
+    }
+    let expression = value.as_str()?.trim();
+    let (tool_name, rest) = expression.split_once('(')?;
+    let command_glob = rest.strip_suffix(')')?;
+    let tool_name = tool_name.trim();
+    let command_glob = command_glob.trim();
+    if tool_name.is_empty() || command_glob.is_empty() {
+        return None;
+    }
+    Some(ClaudeHookCondition::ToolCommandGlob {
+        tool_name: tool_name.to_string(),
+        command_glob: command_glob.to_string(),
+    })
 }
 
 /// Claude-compat: merge hook handlers from a JSON settings file (`--settings FILE`)
@@ -607,11 +687,26 @@ pub(crate) fn append_settings_file_handlers(result: &mut DiscoveryResult, settin
         }
     };
 
-    let parsed: HooksFile = match serde_json::from_str(&contents) {
-        Ok(parsed) => parsed,
+    let mut value: serde_json::Value = match serde_json::from_str(&contents) {
+        Ok(value) => value,
         Err(err) => {
             result.warnings.push(format!(
                 "--settings: failed to parse {} as JSON: {err}",
+                settings_path.display()
+            ));
+            return;
+        }
+    };
+    let claude_conditions = filter_unsupported_claude_hook_if_expressions(
+        settings_path,
+        &mut value,
+        &mut result.warnings,
+    );
+    let parsed: HooksFile = match serde_json::from_value(value) {
+        Ok(parsed) => parsed,
+        Err(err) => {
+            result.warnings.push(format!(
+                "--settings: failed to parse hooks in {}: {err}",
                 settings_path.display()
             ));
             return;
@@ -642,6 +737,7 @@ pub(crate) fn append_settings_file_handlers(result: &mut DiscoveryResult, settin
         hook_states: &hook_states,
         env: HashMap::new(),
         plugin_id: None,
+        claude_conditions,
     };
     let mut display_order = result
         .handlers
@@ -758,6 +854,16 @@ fn append_matcher_groups(
                     r#async,
                     status_message,
                 } => {
+                    let claude_conditions = source
+                        .claude_conditions
+                        .iter()
+                        .find(|condition| {
+                            condition.event_name == event_name
+                                && condition.group_index == group_index
+                                && condition.handler_index == handler_index
+                        })
+                        .map(|condition| condition.conditions.clone())
+                        .unwrap_or_default();
                     if r#async {
                         warnings.push(format!(
                             "skipping async hook in {}: async hooks are not supported yet",
@@ -779,8 +885,13 @@ fn append_matcher_groups(
                         r#async,
                         status_message: status_message.clone(),
                     };
-                    let current_hash =
-                        command_hook_hash(event_name, matcher, &group, normalized_handler);
+                    let current_hash = command_hook_hash(
+                        event_name,
+                        matcher,
+                        &group,
+                        &claude_conditions,
+                        normalized_handler,
+                    );
                     let command = source.env.iter().fold(command, |command, (key, value)| {
                         command.replace(&format!("${{{key}}}"), value)
                     });
@@ -817,7 +928,7 @@ fn append_matcher_groups(
                     {
                         handlers.push(ConfiguredHandler {
                             event_name,
-                            matcher: matcher.map(ToOwned::to_owned),
+                            matcher: encode_claude_conditional_matcher(matcher, &claude_conditions),
                             command,
                             timeout_sec,
                             status_message,
@@ -845,16 +956,19 @@ fn append_matcher_groups(
 /// Hash a normalized, config-derived identity instead of source text so equivalent
 /// hooks from config TOML and hooks.json converge on the same trust identity.
 #[derive(Serialize)]
-struct NormalizedHookIdentity {
+struct NormalizedHookIdentity<'a> {
     event_name: &'static str,
     #[serde(flatten)]
     group: MatcherGroup,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    claude_conditions: Option<&'a [ClaudeHookCondition]>,
 }
 
 fn command_hook_hash(
     event_name: codex_protocol::protocol::HookEventName,
     matcher: Option<&str>,
     group: &MatcherGroup,
+    claude_conditions: &[ClaudeHookCondition],
     normalized_handler: HookHandlerConfig,
 ) -> String {
     let mut group = group.clone();
@@ -863,6 +977,7 @@ fn command_hook_hash(
     let identity = NormalizedHookIdentity {
         event_name: crate::hook_event_key_label(event_name),
         group,
+        claude_conditions: (!claude_conditions.is_empty()).then_some(claude_conditions),
     };
     let Ok(value) = TomlValue::try_from(identity) else {
         unreachable!("normalized hook identity should serialize to TOML");
@@ -968,6 +1083,7 @@ mod tests {
             hook_states,
             env: std::collections::HashMap::new(),
             plugin_id: None,
+            claude_conditions: Vec::new(),
         }
     }
 

--- a/codex-rs/hooks/src/engine/dispatcher.rs
+++ b/codex-rs/hooks/src/engine/dispatcher.rs
@@ -10,16 +10,48 @@ use codex_protocol::protocol::HookRunStatus;
 use codex_protocol::protocol::HookRunSummary;
 use codex_protocol::protocol::HookScope;
 
+use super::command_runner::run_command;
+use super::command_runner::CommandRunResult;
 use super::CommandShell;
 use super::ConfiguredHandler;
-use super::command_runner::CommandRunResult;
-use super::command_runner::run_command;
 use crate::events::common::matches_matcher;
+
+const CLAUDE_CONDITIONAL_MATCHER_PREFIX: &str = "__codex_claude_conditional_matcher__:";
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+pub(crate) enum ClaudeHookCondition {
+    ToolCommandGlob {
+        tool_name: String,
+        command_glob: String,
+    },
+}
+
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+struct ClaudeConditionalMatcher {
+    matcher: Option<String>,
+    conditions: Vec<ClaudeHookCondition>,
+}
 
 #[derive(Debug)]
 pub(crate) struct ParsedHandler<T> {
     pub completed: HookCompletedEvent,
     pub data: T,
+}
+
+pub(crate) fn encode_claude_conditional_matcher(
+    matcher: Option<&str>,
+    conditions: &[ClaudeHookCondition],
+) -> Option<String> {
+    if conditions.is_empty() {
+        return matcher.map(ToOwned::to_owned);
+    }
+    let Ok(encoded) = serde_json::to_string(&ClaudeConditionalMatcher {
+        matcher: matcher.map(ToOwned::to_owned),
+        conditions: conditions.to_vec(),
+    }) else {
+        return matcher.map(ToOwned::to_owned);
+    };
+    Some(format!("{CLAUDE_CONDITIONAL_MATCHER_PREFIX}{encoded}"))
 }
 
 pub(crate) fn select_handlers(
@@ -36,37 +68,122 @@ pub(crate) fn select_handlers_for_matcher_inputs(
     event_name: HookEventName,
     matcher_inputs: &[&str],
 ) -> Vec<ConfiguredHandler> {
+    select_handlers_for_matcher_inputs_and_tool_input(
+        handlers,
+        event_name,
+        matcher_inputs,
+        /*tool_input*/ None,
+    )
+}
+
+pub(crate) fn select_handlers_for_tool_use(
+    handlers: &[ConfiguredHandler],
+    event_name: HookEventName,
+    matcher_inputs: &[&str],
+    tool_input: &serde_json::Value,
+) -> Vec<ConfiguredHandler> {
+    select_handlers_for_matcher_inputs_and_tool_input(
+        handlers,
+        event_name,
+        matcher_inputs,
+        Some(tool_input),
+    )
+}
+
+fn select_handlers_for_matcher_inputs_and_tool_input(
+    handlers: &[ConfiguredHandler],
+    event_name: HookEventName,
+    matcher_inputs: &[&str],
+    tool_input: Option<&serde_json::Value>,
+) -> Vec<ConfiguredHandler> {
     // Check each configured handler once, even when several compatibility names
     // match the same regex. A hook like `apply_patch|Write|Edit` should run a
     // single time for one tool call, not once per matching alias.
     handlers
         .iter()
         .filter(|handler| handler.event_name == event_name)
-        .filter(|handler| match event_name {
-            HookEventName::PreToolUse
-            | HookEventName::PermissionRequest
-            | HookEventName::PostToolUse
-            | HookEventName::PreCompact
-            | HookEventName::PostCompact
-            | HookEventName::PostToolUseFailure
-            | HookEventName::SessionStart
-            | HookEventName::FileChanged => {
-                if matcher_inputs.is_empty() {
-                    matches_matcher(handler.matcher.as_deref(), /*input*/ None)
-                } else {
-                    matcher_inputs
-                        .iter()
-                        .any(|input| matches_matcher(handler.matcher.as_deref(), Some(input)))
+        .filter(|handler| {
+            let parsed = parse_claude_conditional_matcher(handler.matcher.as_deref());
+            let matcher = parsed
+                .as_ref()
+                .map_or(handler.matcher.as_deref(), |parsed| {
+                    parsed.matcher.as_deref()
+                });
+            match event_name {
+                HookEventName::PreToolUse
+                | HookEventName::PermissionRequest
+                | HookEventName::PostToolUse
+                | HookEventName::PreCompact
+                | HookEventName::PostCompact
+                | HookEventName::PostToolUseFailure
+                | HookEventName::SessionStart
+                | HookEventName::FileChanged => {
+                    if matcher_inputs.is_empty() {
+                        matches_matcher(matcher, /*input*/ None)
+                    } else {
+                        matcher_inputs
+                            .iter()
+                            .any(|input| matches_matcher(matcher, Some(input)))
+                    }
                 }
+                HookEventName::Notification
+                | HookEventName::SessionEnd
+                | HookEventName::UserPromptSubmit
+                | HookEventName::Stop
+                | HookEventName::StopFailure => true,
             }
-            HookEventName::Notification
-            | HookEventName::SessionEnd
-            | HookEventName::UserPromptSubmit
-            | HookEventName::Stop
-            | HookEventName::StopFailure => true,
+        })
+        .filter(|handler| {
+            let Some(parsed) = parse_claude_conditional_matcher(handler.matcher.as_deref()) else {
+                return true;
+            };
+            tool_input.is_some_and(|tool_input| {
+                parsed.conditions.iter().all(|condition| {
+                    condition_matches_tool_use(condition, matcher_inputs, tool_input)
+                })
+            })
         })
         .cloned()
         .collect()
+}
+
+fn parse_claude_conditional_matcher(matcher: Option<&str>) -> Option<ClaudeConditionalMatcher> {
+    let encoded = matcher?.strip_prefix(CLAUDE_CONDITIONAL_MATCHER_PREFIX)?;
+    serde_json::from_str(encoded).ok()
+}
+
+fn condition_matches_tool_use(
+    condition: &ClaudeHookCondition,
+    matcher_inputs: &[&str],
+    tool_input: &serde_json::Value,
+) -> bool {
+    match condition {
+        ClaudeHookCondition::ToolCommandGlob {
+            tool_name,
+            command_glob,
+        } => {
+            matcher_inputs.iter().any(|input| input == tool_name)
+                && tool_input
+                    .get("command")
+                    .and_then(serde_json::Value::as_str)
+                    .is_some_and(|command| glob_matches(command_glob, command))
+        }
+    }
+}
+
+fn glob_matches(pattern: &str, input: &str) -> bool {
+    let mut regex_pattern = String::from("^");
+    for ch in pattern.chars() {
+        match ch {
+            '*' => regex_pattern.push_str(".*"),
+            '?' => regex_pattern.push('.'),
+            _ => regex_pattern.push_str(&regex::escape(&ch.to_string())),
+        }
+    }
+    regex_pattern.push('$');
+    regex::Regex::new(&regex_pattern)
+        .map(|regex| regex.is_match(input))
+        .unwrap_or(false)
 }
 
 pub(crate) fn running_summary(handler: &ConfiguredHandler) -> HookRunSummary {
@@ -156,12 +273,12 @@ fn scope_for_event(event_name: HookEventName) -> HookScope {
 mod tests {
     use codex_protocol::protocol::HookEventName;
     use codex_protocol::protocol::HookSource;
-    use codex_utils_absolute_path::test_support::PathBufExt;
     use codex_utils_absolute_path::test_support::test_path_buf;
+    use codex_utils_absolute_path::test_support::PathBufExt;
 
-    use super::ConfiguredHandler;
     use super::select_handlers;
     use super::select_handlers_for_matcher_inputs;
+    use super::ConfiguredHandler;
 
     fn make_handler(
         event_name: HookEventName,

--- a/codex-rs/hooks/src/engine/dispatcher.rs
+++ b/codex-rs/hooks/src/engine/dispatcher.rs
@@ -166,9 +166,70 @@ fn condition_matches_tool_use(
                 && tool_input
                     .get("command")
                     .and_then(serde_json::Value::as_str)
-                    .is_some_and(|command| glob_matches(command_glob, command))
+                    .is_some_and(|command| command_matches_glob(command_glob, command))
         }
     }
+}
+
+fn command_matches_glob(pattern: &str, command: &str) -> bool {
+    if glob_matches(pattern, command) {
+        return true;
+    }
+    let Some(commands) = split_top_level_shell_commands(command) else {
+        return true;
+    };
+    commands
+        .iter()
+        .any(|command| glob_matches(pattern, command.trim()))
+}
+
+fn split_top_level_shell_commands(command: &str) -> Option<Vec<&str>> {
+    let mut commands = Vec::new();
+    let mut start = 0;
+    let mut chars = command.char_indices().peekable();
+    let mut quote = None;
+    let mut escaped = false;
+
+    while let Some((index, ch)) = chars.next() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+        if ch == '\\' {
+            escaped = true;
+            continue;
+        }
+        if let Some(quote_ch) = quote {
+            if ch == quote_ch {
+                quote = None;
+            }
+            continue;
+        }
+        match ch {
+            '\'' | '"' => quote = Some(ch),
+            ';' | '\n' | '&' | '|' => {
+                let next_len = if matches!(ch, '&' | '|')
+                    && chars.peek().is_some_and(|(_, next)| *next == ch)
+                {
+                    chars.next();
+                    ch.len_utf8() * 2
+                } else {
+                    ch.len_utf8()
+                };
+                commands.push(&command[start..index]);
+                start = index + next_len;
+            }
+            '$' if chars.peek().is_some_and(|(_, next)| *next == '(') => return None,
+            '`' | '(' | ')' | '{' | '}' => return None,
+            _ => {}
+        }
+    }
+
+    if escaped || quote.is_some() {
+        return None;
+    }
+    commands.push(&command[start..]);
+    Some(commands)
 }
 
 fn glob_matches(pattern: &str, input: &str) -> bool {

--- a/codex-rs/hooks/src/engine/mod_tests.rs
+++ b/codex-rs/hooks/src/engine/mod_tests.rs
@@ -610,6 +610,83 @@ fn claude_settings_hooks_are_discovered_before_codex_sources() {
     }));
 }
 
+#[test]
+fn claude_settings_bash_if_filters_pre_tool_use_hooks_by_command() {
+    let temp = tempdir().expect("create temp dir");
+    let home = temp.path().join("home");
+    let codex_home = home.join(".codex");
+    let user_claude_dir = home.join(".claude");
+    fs::create_dir_all(&codex_home).expect("create codex home");
+    fs::create_dir_all(&user_claude_dir).expect("create user claude dir");
+    fs::write(
+        user_claude_dir.join("settings.json"),
+        serde_json::json!({
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "^Bash$",
+                    "hooks": [{
+                        "type": "command",
+                        "command": "python3 /tmp/pr-workflow-gate.py",
+                        "if": "Bash(gh pr create*)"
+                    }]
+                }]
+            }
+        })
+        .to_string(),
+    )
+    .expect("write user claude settings");
+
+    let config_layer_stack = ConfigLayerStack::new(
+        vec![ConfigLayerEntry::new(
+            ConfigLayerSource::User {
+                file: AbsolutePathBuf::try_from(codex_home.join("config.toml"))
+                    .expect("absolute user config"),
+            },
+            TomlValue::Table(Default::default()),
+        )],
+        ConfigRequirements::default(),
+        ConfigRequirementsToml::default(),
+    )
+    .expect("config layer stack");
+    let engine = ClaudeHooksEngine::new(
+        /*enabled*/ true,
+        Some(&config_layer_stack),
+        Vec::new(),
+        Vec::new(),
+        CommandShell {
+            program: String::new(),
+            args: Vec::new(),
+        },
+        /*settings_file*/ None,
+    );
+
+    assert_eq!(engine.warnings(), Vec::<String>::new());
+    assert_eq!(engine.handlers.len(), 1);
+
+    let matching_preview =
+        engine.preview_pre_tool_use(&pre_tool_use_request("tool-1", "gh pr create --title test"));
+    assert_eq!(matching_preview.len(), 1);
+
+    let non_matching_preview =
+        engine.preview_pre_tool_use(&pre_tool_use_request("tool-2", "gh issue list"));
+    assert!(non_matching_preview.is_empty());
+}
+
+fn pre_tool_use_request(tool_use_id: &str, command: &str) -> PreToolUseRequest {
+    PreToolUseRequest {
+        session_id: ThreadId::new(),
+        turn_id: "turn-1".to_string(),
+        cwd: cwd(),
+        transcript_path: None,
+        model: "gpt-test".to_string(),
+        permission_mode: "default".to_string(),
+        tool_name: "Bash".to_string(),
+        matcher_aliases: Vec::new(),
+        tool_use_id: tool_use_id.to_string(),
+        tool_input: serde_json::json!({ "command": command }),
+    }
+}
+
 fn config_with_hook_state(key: &str, enabled: bool) -> TomlValue {
     serde_json::from_value(serde_json::json!({
         "hooks": {

--- a/codex-rs/hooks/src/engine/mod_tests.rs
+++ b/codex-rs/hooks/src/engine/mod_tests.rs
@@ -667,8 +667,20 @@ fn claude_settings_bash_if_filters_pre_tool_use_hooks_by_command() {
         engine.preview_pre_tool_use(&pre_tool_use_request("tool-1", "gh pr create --title test"));
     assert_eq!(matching_preview.len(), 1);
 
+    let matching_subcommand_preview = engine.preview_pre_tool_use(&pre_tool_use_request(
+        "tool-2",
+        "cd repo && gh pr create --title test",
+    ));
+    assert_eq!(matching_subcommand_preview.len(), 1);
+
+    let conservative_complex_preview = engine.preview_pre_tool_use(&pre_tool_use_request(
+        "tool-3",
+        "cd $(mktemp -d) && gh issue list",
+    ));
+    assert_eq!(conservative_complex_preview.len(), 1);
+
     let non_matching_preview =
-        engine.preview_pre_tool_use(&pre_tool_use_request("tool-2", "gh issue list"));
+        engine.preview_pre_tool_use(&pre_tool_use_request("tool-4", "gh issue list"));
     assert!(non_matching_preview.is_empty());
 }
 

--- a/codex-rs/hooks/src/events/post_tool_use.rs
+++ b/codex-rs/hooks/src/events/post_tool_use.rs
@@ -1,21 +1,21 @@
 use std::path::PathBuf;
 
-use codex_protocol::ThreadId;
 use codex_protocol::protocol::HookCompletedEvent;
 use codex_protocol::protocol::HookEventName;
 use codex_protocol::protocol::HookOutputEntry;
 use codex_protocol::protocol::HookOutputEntryKind;
 use codex_protocol::protocol::HookRunStatus;
 use codex_protocol::protocol::HookRunSummary;
+use codex_protocol::ThreadId;
 use codex_utils_absolute_path::AbsolutePathBuf;
 use serde_json::Value;
 
 use super::common;
-use crate::engine::CommandShell;
-use crate::engine::ConfiguredHandler;
 use crate::engine::command_runner::CommandRunResult;
 use crate::engine::dispatcher;
 use crate::engine::output_parser;
+use crate::engine::CommandShell;
+use crate::engine::ConfiguredHandler;
 use crate::schema::PostToolUseCommandInput;
 
 #[derive(Debug, Clone)]
@@ -55,10 +55,11 @@ pub(crate) fn preview(
     request: &PostToolUseRequest,
 ) -> Vec<HookRunSummary> {
     let matcher_inputs = common::matcher_inputs(&request.tool_name, &request.matcher_aliases);
-    dispatcher::select_handlers_for_matcher_inputs(
+    dispatcher::select_handlers_for_tool_use(
         handlers,
         HookEventName::PostToolUse,
         &matcher_inputs,
+        &request.tool_input,
     )
     .into_iter()
     .map(|handler| {
@@ -73,10 +74,11 @@ pub(crate) async fn run(
     request: PostToolUseRequest,
 ) -> PostToolUseOutcome {
     let matcher_inputs = common::matcher_inputs(&request.tool_name, &request.matcher_aliases);
-    let matched = dispatcher::select_handlers_for_matcher_inputs(
+    let matched = dispatcher::select_handlers_for_tool_use(
         handlers,
         HookEventName::PostToolUse,
         &matcher_inputs,
+        &request.tool_input,
     );
     if matched.is_empty() {
         return PostToolUseOutcome {
@@ -313,22 +315,22 @@ fn serialization_failure_outcome(hook_events: Vec<HookCompletedEvent>) -> PostTo
 
 #[cfg(test)]
 mod tests {
-    use codex_protocol::ThreadId;
     use codex_protocol::protocol::HookEventName;
     use codex_protocol::protocol::HookOutputEntry;
     use codex_protocol::protocol::HookOutputEntryKind;
     use codex_protocol::protocol::HookRunStatus;
-    use codex_utils_absolute_path::test_support::PathBufExt;
+    use codex_protocol::ThreadId;
     use codex_utils_absolute_path::test_support::test_path_buf;
+    use codex_utils_absolute_path::test_support::PathBufExt;
     use pretty_assertions::assert_eq;
     use serde_json::json;
 
-    use super::PostToolUseHandlerData;
     use super::command_input_json;
     use super::parse_completed;
     use super::preview;
-    use crate::engine::ConfiguredHandler;
+    use super::PostToolUseHandlerData;
     use crate::engine::command_runner::CommandRunResult;
+    use crate::engine::ConfiguredHandler;
     use crate::events::common;
 
     #[test]

--- a/codex-rs/hooks/src/events/pre_tool_use.rs
+++ b/codex-rs/hooks/src/events/pre_tool_use.rs
@@ -1,21 +1,21 @@
 use std::path::PathBuf;
 
-use codex_protocol::ThreadId;
 use codex_protocol::protocol::HookCompletedEvent;
 use codex_protocol::protocol::HookEventName;
 use codex_protocol::protocol::HookOutputEntry;
 use codex_protocol::protocol::HookOutputEntryKind;
 use codex_protocol::protocol::HookRunStatus;
 use codex_protocol::protocol::HookRunSummary;
+use codex_protocol::ThreadId;
 use codex_utils_absolute_path::AbsolutePathBuf;
 use serde_json::Value;
 
 use super::common;
-use crate::engine::CommandShell;
-use crate::engine::ConfiguredHandler;
 use crate::engine::command_runner::CommandRunResult;
 use crate::engine::dispatcher;
 use crate::engine::output_parser;
+use crate::engine::CommandShell;
+use crate::engine::ConfiguredHandler;
 use crate::schema::PreToolUseCommandInput;
 
 #[derive(Debug, Clone)]
@@ -52,10 +52,11 @@ pub(crate) fn preview(
     request: &PreToolUseRequest,
 ) -> Vec<HookRunSummary> {
     let matcher_inputs = common::matcher_inputs(&request.tool_name, &request.matcher_aliases);
-    dispatcher::select_handlers_for_matcher_inputs(
+    dispatcher::select_handlers_for_tool_use(
         handlers,
         HookEventName::PreToolUse,
         &matcher_inputs,
+        &request.tool_input,
     )
     .into_iter()
     .map(|handler| {
@@ -70,10 +71,11 @@ pub(crate) async fn run(
     request: PreToolUseRequest,
 ) -> PreToolUseOutcome {
     let matcher_inputs = common::matcher_inputs(&request.tool_name, &request.matcher_aliases);
-    let matched = dispatcher::select_handlers_for_matcher_inputs(
+    let matched = dispatcher::select_handlers_for_tool_use(
         handlers,
         HookEventName::PreToolUse,
         &matcher_inputs,
+        &request.tool_input,
     );
     if matched.is_empty() {
         return PreToolUseOutcome {
@@ -273,21 +275,21 @@ fn serialization_failure_outcome(hook_events: Vec<HookCompletedEvent>) -> PreToo
 
 #[cfg(test)]
 mod tests {
-    use codex_protocol::ThreadId;
     use codex_protocol::protocol::HookEventName;
     use codex_protocol::protocol::HookOutputEntry;
     use codex_protocol::protocol::HookOutputEntryKind;
     use codex_protocol::protocol::HookRunStatus;
-    use codex_utils_absolute_path::test_support::PathBufExt;
+    use codex_protocol::ThreadId;
     use codex_utils_absolute_path::test_support::test_path_buf;
+    use codex_utils_absolute_path::test_support::PathBufExt;
     use pretty_assertions::assert_eq;
 
-    use super::PreToolUseHandlerData;
     use super::command_input_json;
     use super::parse_completed;
     use super::preview;
-    use crate::engine::ConfiguredHandler;
+    use super::PreToolUseHandlerData;
     use crate::engine::command_runner::CommandRunResult;
+    use crate::engine::ConfiguredHandler;
     use crate::events::common;
 
     #[test]


### PR DESCRIPTION
## Summary
- Preserve supported Claude hook-level and group-level `if` expressions while importing Claude settings hooks.
- Support the common `Bash(<command glob>)` condition for `PreToolUse` and `PostToolUse`, including user/project Claude settings and `--settings` JSON injection.
- Evaluate conditional hooks against the shell command in `tool_input.command`, so `Bash(gh pr create*)` fires for PR creation but not unrelated Bash commands.

Closes #55.

## Test plan
- `cargo test -p codex-hooks claude_settings_bash_if_filters_pre_tool_use_hooks_by_command`
- Confirmed the new regression test fails on `origin/feat/claude-compat` with the old warning: `hook-level if expressions are not supported`.
- `cargo test -p codex-hooks`
- `/home/jean/.cargo/bin/just fix -p codex-hooks`
- `cargo clippy -p codex-hooks --tests -- -D warnings`
- `cargo check --workspace`
