### PR TITLE
feat(cli): accept --plugin-dir flag for supervisor skill injection

### DIFF
--- a/codex-rs/cli/src/main.rs
+++ b/codex-rs/cli/src/main.rs
@@ -1504,6 +1504,7 @@ async fn run_debug_prompt_input_command(
         show_raw_agent_reasoning: shared.oss.then_some(true),
         ephemeral: Some(true),
         additional_writable_roots: shared.add_dir,
+        cli_plugin_dirs: shared.plugin_dirs,
         ..Default::default()
     };
     let config =

--- a/codex-rs/core/src/config/config_tests.rs
+++ b/codex-rs/core/src/config/config_tests.rs
@@ -7090,6 +7090,7 @@ async fn test_precedence_fixture_with_o3_profile() -> std::io::Result<()> {
             tui_session_picker_view: SessionPickerViewMode::Dense,
             otel: OtelConfig::default(),
             settings_file: None,
+            cli_plugin_dirs: Vec::new(),
         },
         o3_profile_config
     );
@@ -7538,6 +7539,7 @@ async fn test_precedence_fixture_with_gpt3_profile() -> std::io::Result<()> {
         tui_session_picker_view: SessionPickerViewMode::Dense,
         otel: OtelConfig::default(),
         settings_file: None,
+        cli_plugin_dirs: Vec::new(),
     };
 
     assert_eq!(expected_gpt3_profile_config, gpt3_profile_config);
@@ -7700,6 +7702,7 @@ async fn test_precedence_fixture_with_zdr_profile() -> std::io::Result<()> {
         tui_session_picker_view: SessionPickerViewMode::Dense,
         otel: OtelConfig::default(),
         settings_file: None,
+        cli_plugin_dirs: Vec::new(),
     };
 
     assert_eq!(expected_zdr_profile_config, zdr_profile_config);
@@ -7847,6 +7850,7 @@ async fn test_precedence_fixture_with_gpt5_profile() -> std::io::Result<()> {
         tui_session_picker_view: SessionPickerViewMode::Dense,
         otel: OtelConfig::default(),
         settings_file: None,
+        cli_plugin_dirs: Vec::new(),
     };
 
     assert_eq!(expected_gpt5_profile_config, gpt5_profile_config);

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -821,6 +821,12 @@ pub struct Config {
     /// Path to a JSON settings file containing additional hook definitions.
     /// Used by external supervisors (e.g. Looper) to inject per-session hooks.
     pub settings_file: Option<PathBuf>,
+
+    /// Additional plugin directories supplied via the `--plugin-dir` CLI flag.
+    /// Each directory's `skills/` subdirectory becomes an extra skill root.
+    /// Empty by default. Used by external supervisors (e.g. Kookr) to inject
+    /// curated toolkits without modifying user-scope marketplace state.
+    pub cli_plugin_dirs: Vec<PathBuf>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -1885,6 +1891,10 @@ pub struct ConfigOverrides {
     /// Merged additively with config.toml hooks. Used by external supervisors
     /// (e.g. Looper) to inject per-session hooks.
     pub settings_file: Option<PathBuf>,
+
+    /// Additional plugin directories from `--plugin-dir`. Each becomes an
+    /// extra skill root via its `skills/` subdirectory.
+    pub cli_plugin_dirs: Vec<PathBuf>,
 }
 
 /// Resolves the OSS provider from CLI override, profile config, or global config.
@@ -2160,6 +2170,7 @@ impl Config {
             ephemeral,
             additional_writable_roots,
             settings_file,
+            cli_plugin_dirs,
         } = overrides;
 
         if sandbox_mode.is_some() && permission_profile.is_some() {
@@ -3214,6 +3225,7 @@ impl Config {
                 .unwrap_or_default(),
             otel,
             settings_file,
+            cli_plugin_dirs,
         };
         Ok(config)
         })

--- a/codex-rs/core/src/lib.rs
+++ b/codex-rs/core/src/lib.rs
@@ -100,6 +100,7 @@ pub(crate) use skills::build_skill_name_counts;
 pub(crate) use skills::collect_env_var_dependencies;
 pub(crate) use skills::collect_explicit_skill_mentions;
 pub(crate) use skills::default_skill_metadata_budget;
+pub(crate) use skills::include_cli_plugin_skill_roots;
 pub(crate) use skills::injection;
 pub(crate) use skills::manager;
 pub(crate) use skills::maybe_emit_implicit_skill_invocation;

--- a/codex-rs/core/src/session/mod.rs
+++ b/codex-rs/core/src/session/mod.rs
@@ -33,6 +33,7 @@ use crate::context::PersonalitySpecInstructions;
 use crate::default_skill_metadata_budget;
 use crate::environment_selection::ResolvedTurnEnvironments;
 use crate::exec_policy::ExecPolicyManager;
+use crate::include_cli_plugin_skill_roots;
 use crate::parse_turn_item;
 use crate::path_utils::normalize_for_native_workdir;
 use crate::realtime_conversation::RealtimeConversationManager;
@@ -477,7 +478,10 @@ impl Codex {
         let fs = environment_selections.primary_filesystem();
         let plugins_input = config.plugins_config_input();
         let plugin_outcome = plugins_manager.plugins_for_config(&plugins_input).await;
-        let effective_skill_roots = plugin_outcome.effective_plugin_skill_roots();
+        let effective_skill_roots = include_cli_plugin_skill_roots(
+            &config,
+            plugin_outcome.effective_plugin_skill_roots(),
+        );
         let skills_input = skills_load_input_from_config(&config, effective_skill_roots);
         let loaded_skills = skills_manager.skills_for_config(&skills_input, fs).await;
 

--- a/codex-rs/core/src/session/turn_context.rs
+++ b/codex-rs/core/src/session/turn_context.rs
@@ -714,7 +714,10 @@ impl Session {
             .plugins_manager
             .plugins_for_config(&per_turn_config.plugins_config_input())
             .await;
-        let effective_skill_roots = plugin_outcome.effective_plugin_skill_roots();
+        let effective_skill_roots = include_cli_plugin_skill_roots(
+            &per_turn_config,
+            plugin_outcome.effective_plugin_skill_roots(),
+        );
         let skills_input = skills_load_input_from_config(&per_turn_config, effective_skill_roots);
         let fs = primary_turn_environment
             .map(|turn_environment| turn_environment.environment.get_filesystem());

--- a/codex-rs/core/src/skills.rs
+++ b/codex-rs/core/src/skills.rs
@@ -56,6 +56,23 @@ pub(crate) fn skills_load_input_from_config(
     )
 }
 
+pub(crate) fn include_cli_plugin_skill_roots(
+    config: &Config,
+    mut effective_skill_roots: Vec<PluginSkillRoot>,
+) -> Vec<PluginSkillRoot> {
+    for cli_plugin_dir in &config.cli_plugin_dirs {
+        if let Some(root) = codex_utils_plugins::plugin_skill_root_from_cli_dir(cli_plugin_dir) {
+            effective_skill_roots.push(root);
+        } else {
+            warn!(
+                "--plugin-dir {} skipped: no readable plugin manifest at .codex-plugin/plugin.json or .claude-plugin/plugin.json",
+                cli_plugin_dir.display()
+            );
+        }
+    }
+    effective_skill_roots
+}
+
 pub(crate) async fn resolve_skill_dependencies_for_turn(
     sess: &Arc<Session>,
     turn_context: &Arc<TurnContext>,
@@ -231,4 +248,42 @@ pub(crate) async fn maybe_emit_implicit_skill_invocation(
             ),
             vec![invocation],
         );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use codex_utils_absolute_path::AbsolutePathBuf;
+    use pretty_assertions::assert_eq;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[tokio::test]
+    async fn include_cli_plugin_skill_roots_adds_roots_from_config() {
+        let tmp = tempdir().expect("tempdir");
+        let plugin_root = tmp.path().join("plugins/kookr");
+        fs::create_dir_all(plugin_root.join(".codex-plugin")).expect("mkdir manifest");
+        fs::create_dir_all(plugin_root.join("skills")).expect("mkdir skills");
+        fs::write(
+            plugin_root.join(".codex-plugin/plugin.json"),
+            r#"{"name":"kookr-toolkit"}"#,
+        )
+        .expect("write manifest");
+
+        let mut config = crate::config::test_config().await;
+        config.cli_plugin_dirs = vec![plugin_root.clone()];
+        let canonical_plugin_root = fs::canonicalize(plugin_root).expect("canonical plugin root");
+        let expected_skill_root =
+            AbsolutePathBuf::from_absolute_path_checked(canonical_plugin_root)
+                .expect("absolute plugin root")
+                .join("skills");
+
+        assert_eq!(
+            include_cli_plugin_skill_roots(&config, Vec::new()),
+            vec![PluginSkillRoot {
+                path: expected_skill_root,
+                plugin_id: "kookr-toolkit".to_string(),
+            }]
+        );
+    }
 }

--- a/codex-rs/exec/src/lib.rs
+++ b/codex-rs/exec/src/lib.rs
@@ -266,6 +266,7 @@ pub async fn run_main(cli: Cli, arg0_paths: Arg0DispatchPaths) -> anyhow::Result
         dangerously_bypass_approvals_and_sandbox,
         cwd,
         add_dir,
+        plugin_dirs,
     } = shared;
 
     let (_stdout_with_ansi, stderr_with_ansi) = match color {
@@ -424,6 +425,7 @@ pub async fn run_main(cli: Cli, arg0_paths: Arg0DispatchPaths) -> anyhow::Result
         ephemeral: ephemeral.then_some(true),
         additional_writable_roots: add_dir,
         settings_file: config_overrides.settings_file.clone(),
+        cli_plugin_dirs: plugin_dirs,
     };
 
     let config = ConfigBuilder::default()

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -887,6 +887,7 @@ pub async fn run_main(
         show_raw_agent_reasoning: cli.oss.then_some(true),
         additional_writable_roots: additional_dirs,
         settings_file: cli.config_overrides.settings_file.clone(),
+        cli_plugin_dirs: cli.plugin_dirs.clone(),
         ..Default::default()
     };
 

--- a/codex-rs/utils/cli/src/shared_options.rs
+++ b/codex-rs/utils/cli/src/shared_options.rs
@@ -54,6 +54,14 @@ pub struct SharedCliOptions {
     /// Additional directories that should be writable alongside the primary workspace.
     #[arg(long = "add-dir", value_name = "DIR", value_hint = clap::ValueHint::DirPath)]
     pub add_dir: Vec<PathBuf>,
+
+    /// Additional plugin directories whose `skills/` subdirectory will be loaded
+    /// as extra skill roots. Each directory must contain a manifest at
+    /// `.claude-plugin/plugin.json` or `.codex-plugin/plugin.json` defining
+    /// the plugin's `name`. May be specified multiple times. Mirrors
+    /// Claude Code's `--plugin-dir` flag for symmetric supervisor injection.
+    #[arg(long = "plugin-dir", value_name = "DIR", value_hint = clap::ValueHint::DirPath)]
+    pub plugin_dirs: Vec<PathBuf>,
 }
 
 impl SharedCliOptions {
@@ -70,6 +78,7 @@ impl SharedCliOptions {
             dangerously_bypass_approvals_and_sandbox,
             cwd,
             add_dir,
+            plugin_dirs,
         } = self;
         let Self {
             images: root_images,
@@ -81,6 +90,7 @@ impl SharedCliOptions {
             dangerously_bypass_approvals_and_sandbox: root_dangerously_bypass_approvals_and_sandbox,
             cwd: root_cwd,
             add_dir: root_add_dir,
+            plugin_dirs: root_plugin_dirs,
         } = root;
 
         if model.is_none() {
@@ -115,6 +125,11 @@ impl SharedCliOptions {
             merged_add_dir.append(add_dir);
             *add_dir = merged_add_dir;
         }
+        if !root_plugin_dirs.is_empty() {
+            let mut merged_plugin_dirs = root_plugin_dirs.clone();
+            merged_plugin_dirs.append(plugin_dirs);
+            *plugin_dirs = merged_plugin_dirs;
+        }
     }
 
     pub fn apply_subcommand_overrides(&mut self, subcommand: Self) {
@@ -130,6 +145,7 @@ impl SharedCliOptions {
             dangerously_bypass_approvals_and_sandbox,
             cwd,
             add_dir,
+            plugin_dirs,
         } = subcommand;
 
         if let Some(model) = model {
@@ -157,6 +173,9 @@ impl SharedCliOptions {
         }
         if !add_dir.is_empty() {
             self.add_dir.extend(add_dir);
+        }
+        if !plugin_dirs.is_empty() {
+            self.plugin_dirs.extend(plugin_dirs);
         }
     }
 }

--- a/codex-rs/utils/plugins/src/lib.rs
+++ b/codex-rs/utils/plugins/src/lib.rs
@@ -9,6 +9,7 @@ pub mod plugin_namespace;
 
 pub use plugin_namespace::find_plugin_manifest_path;
 pub use plugin_namespace::plugin_namespace_for_skill_path;
+pub use plugin_namespace::plugin_skill_root_from_cli_dir;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct PluginSkillRoot {

--- a/codex-rs/utils/plugins/src/plugin_namespace.rs
+++ b/codex-rs/utils/plugins/src/plugin_namespace.rs
@@ -1,5 +1,6 @@
 //! Resolve plugin namespace from skill file paths by walking ancestors for `plugin.json`.
 
+use crate::PluginSkillRoot;
 use codex_exec_server::ExecutorFileSystem;
 use codex_utils_absolute_path::AbsolutePathBuf;
 use std::path::Path;
@@ -13,6 +14,33 @@ pub fn find_plugin_manifest_path(plugin_root: &Path) -> Option<PathBuf> {
         .iter()
         .map(|relative_path| plugin_root.join(relative_path))
         .find(|manifest_path| manifest_path.is_file())
+}
+
+/// Build a [`PluginSkillRoot`] from a directory passed via `--plugin-dir`.
+///
+/// Reads the plugin manifest at `<dir>/.codex-plugin/plugin.json` or
+/// `<dir>/.claude-plugin/plugin.json` (in that order) for the plugin's
+/// `name`. Returns `None` if the directory has no manifest, the manifest
+/// is unreadable, or the `<dir>/skills/` subdirectory cannot be resolved.
+///
+/// Used by the CLI `--plugin-dir` flag to inject extra skill roots
+/// without going through the marketplace install flow. Mirrors Claude
+/// Code's `--plugin-dir` semantics for symmetric supervisor injection.
+pub fn plugin_skill_root_from_cli_dir(dir: &Path) -> Option<PluginSkillRoot> {
+    let manifest_path = find_plugin_manifest_path(dir)?;
+    let contents = std::fs::read_to_string(&manifest_path).ok()?;
+    let raw: RawPluginManifestName = serde_json::from_str(&contents).ok()?;
+    let name = if raw.name.trim().is_empty() {
+        dir.file_name()?.to_str()?.to_string()
+    } else {
+        raw.name
+    };
+    let canonical = std::fs::canonicalize(dir).ok()?;
+    let abs_dir = AbsolutePathBuf::from_absolute_path_checked(canonical).ok()?;
+    Some(PluginSkillRoot {
+        path: abs_dir.join("skills"),
+        plugin_id: name,
+    })
 }
 
 #[derive(serde::Deserialize)]
@@ -117,5 +145,67 @@ mod tests {
             Some("sample".to_string())
         );
         assert_eq!(find_plugin_manifest_path(&plugin_root), Some(manifest_path));
+    }
+
+    #[test]
+    fn plugin_skill_root_from_cli_dir_resolves_codex_manifest() {
+        use super::plugin_skill_root_from_cli_dir;
+        let tmp = tempdir().expect("tempdir");
+        let plugin_root = tmp.path().join("plugins/codex-style");
+        fs::create_dir_all(plugin_root.join(".codex-plugin")).expect("mkdir codex-plugin");
+        fs::create_dir_all(plugin_root.join("skills")).expect("mkdir skills");
+        fs::write(
+            plugin_root.join(".codex-plugin/plugin.json"),
+            r#"{"name":"my-toolkit"}"#,
+        )
+        .expect("write manifest");
+
+        let root = plugin_skill_root_from_cli_dir(&plugin_root).expect("plugin root resolved");
+        assert_eq!(root.plugin_id, "my-toolkit");
+        assert!(root.path.as_path().ends_with("skills"));
+    }
+
+    #[test]
+    fn plugin_skill_root_from_cli_dir_resolves_claude_manifest() {
+        use super::plugin_skill_root_from_cli_dir;
+        let tmp = tempdir().expect("tempdir");
+        let plugin_root = tmp.path().join("plugins/claude-style");
+        fs::create_dir_all(plugin_root.join(".claude-plugin")).expect("mkdir claude-plugin");
+        fs::create_dir_all(plugin_root.join("skills")).expect("mkdir skills");
+        fs::write(
+            plugin_root.join(".claude-plugin/plugin.json"),
+            r#"{"name":"kookr-toolkit"}"#,
+        )
+        .expect("write manifest");
+
+        let root = plugin_skill_root_from_cli_dir(&plugin_root).expect("plugin root resolved");
+        assert_eq!(root.plugin_id, "kookr-toolkit");
+    }
+
+    #[test]
+    fn plugin_skill_root_from_cli_dir_returns_none_when_manifest_missing() {
+        use super::plugin_skill_root_from_cli_dir;
+        let tmp = tempdir().expect("tempdir");
+        let plugin_root = tmp.path().join("plugins/no-manifest");
+        fs::create_dir_all(&plugin_root).expect("mkdir");
+
+        assert!(plugin_skill_root_from_cli_dir(&plugin_root).is_none());
+    }
+
+    #[test]
+    fn plugin_skill_root_from_cli_dir_falls_back_to_dirname_for_empty_name() {
+        use super::plugin_skill_root_from_cli_dir;
+        let tmp = tempdir().expect("tempdir");
+        let plugin_root = tmp.path().join("plugins/fallback-name");
+        fs::create_dir_all(plugin_root.join(".codex-plugin")).expect("mkdir codex-plugin");
+        fs::create_dir_all(plugin_root.join("skills")).expect("mkdir skills");
+        fs::write(
+            plugin_root.join(".codex-plugin/plugin.json"),
+            r#"{"name":"   "}"#,
+        )
+        .expect("write manifest");
+
+        let root = plugin_skill_root_from_cli_dir(&plugin_root).expect("plugin root resolved");
+        assert_eq!(root.plugin_id, "fallback-name");
     }
 }


### PR DESCRIPTION
## Summary
- add shared `--plugin-dir <DIR>` CLI support for interactive/debug/headless entrypoints
- load `.codex-plugin` and `.claude-plugin` manifests as extra plugin skill roots
- ensure CLI plugin roots are included during per-turn skill loading, not only startup

## Verification
- `~/.cargo/bin/just fmt` (ran; stripped unrelated rustfmt churn before commit)
- `cargo test -p codex-utils-plugins plugin_skill_root_from_cli_dir`
- `cargo test -p codex-core include_cli_plugin_skill_roots`
- `cargo check -p codex-utils-plugins -p codex-utils-cli -p codex-core`
- `cargo clippy -p codex-core --tests --no-deps`

Supersedes #52, which was based on stale `feat/claude-compat` history and showed a 104-file conflicting diff.