### PR TITLE
Move Claude compat behavior into leaf helpers

### DIFF
--- a/codex-rs/app-server/src/config_manager.rs
+++ b/codex-rs/app-server/src/config_manager.rs
@@ -23,6 +23,8 @@ use std::sync::RwLock;
 use toml::Value as TomlValue;
 use tracing::warn;
 
+use crate::process_config_overrides::apply_process_settings_file;
+
 /// Shared app-server entry point for loading effective Codex configuration.
 #[derive(Clone)]
 pub(crate) struct ConfigManager {
@@ -237,9 +239,7 @@ impl ConfigManager {
             )
             .collect::<Vec<_>>();
         let mut typesafe_overrides = typesafe_overrides;
-        if typesafe_overrides.settings_file.is_none() {
-            typesafe_overrides.settings_file = self.process_settings_file.clone();
-        }
+        apply_process_settings_file(&mut typesafe_overrides, &self.process_settings_file);
 
         let mut config = codex_core::config::ConfigBuilder::default()
             .codex_home(self.codex_home.clone())

--- a/codex-rs/app-server/src/lib.rs
+++ b/codex-rs/app-server/src/lib.rs
@@ -90,6 +90,7 @@ mod mcp_refresh;
 mod message_processor;
 mod models;
 mod outgoing_message;
+mod process_config_overrides;
 mod request_processors;
 mod request_serialization;
 mod server_request_error;
@@ -423,7 +424,6 @@ pub async fn run_main_with_transport_options(
     auth: AppServerWebsocketAuthSettings,
     runtime_options: AppServerRuntimeOptions,
 ) -> IoResult<()> {
-    let settings_file = cli_config_overrides.settings_file.clone();
     let (transport_event_tx, mut transport_event_rx) =
         mpsc::channel::<TransportEvent>(CHANNEL_CAPACITY);
     let (outgoing_tx, mut outgoing_rx) = mpsc::channel::<OutgoingEnvelope>(CHANNEL_CAPACITY);
@@ -459,7 +459,7 @@ pub async fn run_main_with_transport_options(
         arg0_paths.clone(),
         Arc::new(NoopThreadConfigLoader),
     )
-    .with_process_settings_file(settings_file);
+    .with_process_settings_file(cli_config_overrides.settings_file.clone());
     match config_manager
         .load_latest_config(/*fallback_cwd*/ None)
         .await

--- a/codex-rs/app-server/src/process_config_overrides.rs
+++ b/codex-rs/app-server/src/process_config_overrides.rs
@@ -1,0 +1,24 @@
+use codex_core::config::Config;
+use codex_core::config::ConfigOverrides;
+use std::path::PathBuf;
+
+pub(crate) fn apply_process_settings_file(
+    overrides: &mut ConfigOverrides,
+    process_settings_file: &Option<PathBuf>,
+) {
+    if overrides.settings_file.is_none() {
+        overrides.settings_file = process_settings_file.clone();
+    }
+}
+
+pub(crate) fn apply_thread_runtime_overrides(overrides: &mut ConfigOverrides, config: &Config) {
+    if overrides.settings_file.is_none() {
+        overrides.settings_file = config.settings_file.clone();
+    }
+    if overrides.bypass_hook_trust.is_none() {
+        overrides.bypass_hook_trust = Some(config.bypass_hook_trust);
+    }
+    if overrides.cli_plugin_dirs.is_empty() {
+        overrides.cli_plugin_dirs = config.cli_plugin_dirs.clone();
+    }
+}

--- a/codex-rs/app-server/src/request_processors/thread_processor.rs
+++ b/codex-rs/app-server/src/request_processors/thread_processor.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::error_code::method_not_found;
+use crate::process_config_overrides::apply_thread_runtime_overrides;
 use codex_protocol::models::BUILT_IN_PERMISSION_PROFILE_DANGER_FULL_ACCESS;
 use codex_protocol::models::BUILT_IN_PERMISSION_PROFILE_WORKSPACE;
 
@@ -1268,15 +1269,7 @@ impl ThreadRequestProcessor {
     }
 
     fn apply_process_thread_config_overrides(&self, overrides: &mut ConfigOverrides) {
-        if overrides.settings_file.is_none() {
-            overrides.settings_file = self.config.settings_file.clone();
-        }
-        if overrides.bypass_hook_trust.is_none() {
-            overrides.bypass_hook_trust = Some(self.config.bypass_hook_trust);
-        }
-        if overrides.cli_plugin_dirs.is_empty() {
-            overrides.cli_plugin_dirs = self.config.cli_plugin_dirs.clone();
-        }
+        apply_thread_runtime_overrides(overrides, &self.config);
     }
 
     fn parse_environment_selections(

--- a/codex-rs/cli/src/main.rs
+++ b/codex-rs/cli/src/main.rs
@@ -52,6 +52,7 @@ mod doctor;
 mod marketplace_cmd;
 mod mcp_cmd;
 mod plugin_cmd;
+mod prompt_file;
 mod state_db_recovery;
 #[cfg(not(windows))]
 mod wsl_paths;
@@ -79,6 +80,7 @@ use codex_models_manager::manager::RefreshStrategy;
 use codex_protocol::protocol::AskForApproval;
 use codex_protocol::user_input::UserInput;
 use codex_terminal_detection::TerminalName;
+use prompt_file::resolve_prompt_file;
 
 /// Codex CLI
 ///
@@ -1927,54 +1929,6 @@ fn read_remote_auth_token_from_env_var(env_var_name: &str) -> anyhow::Result<Str
     read_remote_auth_token_from_env_var_with(env_var_name, |name| std::env::var(name))
 }
 
-/// Upper bound on `--prompt-file` size. The positional `PROMPT` argument is
-/// implicitly capped by `ARG_MAX` (~2 MiB usable); `--prompt-file` removes that
-/// ceiling, so a hard limit is reintroduced here to keep an accidental log or
-/// binary file from allocating unbounded memory at startup and injecting a
-/// runaway initial context item. 10 MiB is far above any real task prompt
-/// (which cannot usefully exceed the model context window) yet well below
-/// "pointed at the wrong file" territory.
-const MAX_PROMPT_FILE_BYTES: u64 = 10 * 1024 * 1024;
-
-/// Fold `--prompt-file` into the positional `prompt` slot. After this runs the
-/// file-sourced prompt is indistinguishable from a positional CLI prompt: it
-/// sets `skip_update_prompt` and is submitted internally via
-/// `create_initial_user_message`, so an orchestrator launching Codex in a PTY
-/// can deliver the initial prompt without a terminal-input race.
-///
-/// `--prompt-file` and a positional `PROMPT` are mutually exclusive at the clap
-/// layer; the `prompt.is_some()` guard only matters if the two ever arrive
-/// through separate arg matchers (base CLI vs. a flattened subcommand).
-///
-/// The file size is checked against [`MAX_PROMPT_FILE_BYTES`] before it is read,
-/// so an oversized file is rejected rather than read into memory.
-fn resolve_prompt_file(interactive: &mut TuiCli) -> std::io::Result<()> {
-    if interactive.prompt.is_some() {
-        return Ok(());
-    }
-    if let Some(path) = interactive.prompt_file.take() {
-        let read_err = |e: std::io::Error| {
-            std::io::Error::new(
-                e.kind(),
-                format!("failed to read --prompt-file {}: {e}", path.display()),
-            )
-        };
-        let len = std::fs::metadata(&path).map_err(&read_err)?.len();
-        if len > MAX_PROMPT_FILE_BYTES {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                format!(
-                    "--prompt-file {} is {len} bytes, over the {MAX_PROMPT_FILE_BYTES}-byte limit",
-                    path.display(),
-                ),
-            ));
-        }
-        let text = std::fs::read_to_string(&path).map_err(&read_err)?;
-        interactive.prompt = Some(text);
-    }
-    Ok(())
-}
-
 async fn run_interactive_tui(
     mut interactive: TuiCli,
     remote: Option<String>,
@@ -3445,70 +3399,6 @@ mod tests {
             result.is_err(),
             "positional PROMPT + --prompt-file must conflict"
         );
-    }
-
-    #[test]
-    fn resolve_prompt_file_reads_file_into_prompt() {
-        let path = std::env::temp_dir().join(format!(
-            "codex-prompt-file-resolve-{}.txt",
-            std::process::id()
-        ));
-        std::fs::write(&path, "do the thing").expect("write temp prompt");
-        let mut cli = MultitoolCli::try_parse_from([
-            "codex",
-            "--prompt-file",
-            path.to_str().expect("utf8 path"),
-        ])
-        .expect("parse should succeed")
-        .interactive;
-
-        resolve_prompt_file(&mut cli).expect("resolve should succeed");
-
-        assert_eq!(cli.prompt.as_deref(), Some("do the thing"));
-        assert_eq!(cli.prompt_file, None);
-        let _ = std::fs::remove_file(&path);
-    }
-
-    #[test]
-    fn resolve_prompt_file_missing_file_is_error() {
-        let mut cli = MultitoolCli::try_parse_from([
-            "codex",
-            "--prompt-file",
-            "/nonexistent/codex-prompt-file/zzz.txt",
-        ])
-        .expect("parse should succeed")
-        .interactive;
-
-        let err = resolve_prompt_file(&mut cli).expect_err("missing file must error");
-        assert!(
-            err.to_string().contains("--prompt-file"),
-            "error should name the flag: {err}"
-        );
-    }
-
-    #[test]
-    fn resolve_prompt_file_rejects_oversize_file() {
-        let path = std::env::temp_dir().join(format!(
-            "codex-prompt-file-oversize-{}.txt",
-            std::process::id()
-        ));
-        std::fs::write(&path, vec![b'x'; MAX_PROMPT_FILE_BYTES as usize + 1])
-            .expect("write oversize temp prompt");
-        let mut cli = MultitoolCli::try_parse_from([
-            "codex",
-            "--prompt-file",
-            path.to_str().expect("utf8 path"),
-        ])
-        .expect("parse should succeed")
-        .interactive;
-
-        let err = resolve_prompt_file(&mut cli).expect_err("oversize file must error");
-        let _ = std::fs::remove_file(&path);
-        assert!(
-            err.to_string().contains("limit"),
-            "error should mention the size limit: {err}"
-        );
-        assert_eq!(cli.prompt, None, "oversize file must not populate the prompt");
     }
 
     #[test]

--- a/codex-rs/cli/src/prompt_file.rs
+++ b/codex-rs/cli/src/prompt_file.rs
@@ -1,0 +1,113 @@
+use codex_tui::Cli as TuiCli;
+
+/// Upper bound on `--prompt-file` size. The positional `PROMPT` argument is
+/// implicitly capped by `ARG_MAX` (~2 MiB usable); `--prompt-file` removes that
+/// ceiling, so a hard limit is reintroduced here to keep an accidental log or
+/// binary file from allocating unbounded memory at startup and injecting a
+/// runaway initial context item. 10 MiB is far above any real task prompt
+/// (which cannot usefully exceed the model context window) yet well below
+/// "pointed at the wrong file" territory.
+const MAX_PROMPT_FILE_BYTES: u64 = 10 * 1024 * 1024;
+
+/// Fold `--prompt-file` into the positional `prompt` slot. After this runs the
+/// file-sourced prompt is indistinguishable from a positional CLI prompt: it
+/// sets `skip_update_prompt` and is submitted internally via
+/// `create_initial_user_message`, so an orchestrator launching Codex in a PTY
+/// can deliver the initial prompt without a terminal-input race.
+///
+/// `--prompt-file` and a positional `PROMPT` are mutually exclusive at the clap
+/// layer; the `prompt.is_some()` guard only matters if the two ever arrive
+/// through separate arg matchers (base CLI vs. a flattened subcommand).
+///
+/// The file size is checked against [`MAX_PROMPT_FILE_BYTES`] before it is read,
+/// so an oversized file is rejected rather than read into memory.
+pub(crate) fn resolve_prompt_file(interactive: &mut TuiCli) -> std::io::Result<()> {
+    if interactive.prompt.is_some() {
+        return Ok(());
+    }
+    if let Some(path) = interactive.prompt_file.take() {
+        let read_err = |e: std::io::Error| {
+            std::io::Error::new(
+                e.kind(),
+                format!("failed to read --prompt-file {}: {e}", path.display()),
+            )
+        };
+        let len = std::fs::metadata(&path).map_err(&read_err)?.len();
+        if len > MAX_PROMPT_FILE_BYTES {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!(
+                    "--prompt-file {} is {len} bytes, over the {MAX_PROMPT_FILE_BYTES}-byte limit",
+                    path.display(),
+                ),
+            ));
+        }
+        let text = std::fs::read_to_string(&path).map_err(&read_err)?;
+        interactive.prompt = Some(text);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[test]
+    fn reads_file_into_prompt() {
+        let path = std::env::temp_dir().join(format!(
+            "codex-prompt-file-resolve-{}.txt",
+            std::process::id()
+        ));
+        std::fs::write(&path, "do the thing").expect("write temp prompt");
+        let mut cli =
+            TuiCli::try_parse_from(["codex", "--prompt-file", path.to_str().expect("utf8 path")])
+                .expect("parse should succeed");
+
+        resolve_prompt_file(&mut cli).expect("resolve should succeed");
+
+        assert_eq!(cli.prompt.as_deref(), Some("do the thing"));
+        assert_eq!(cli.prompt_file, None);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn missing_file_is_error() {
+        let mut cli = TuiCli::try_parse_from([
+            "codex",
+            "--prompt-file",
+            "/nonexistent/codex-prompt-file/zzz.txt",
+        ])
+        .expect("parse should succeed");
+
+        let err = resolve_prompt_file(&mut cli).expect_err("missing file must error");
+        assert!(
+            err.to_string().contains("--prompt-file"),
+            "error should name the flag: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_oversize_file() {
+        let path = std::env::temp_dir().join(format!(
+            "codex-prompt-file-oversize-{}.txt",
+            std::process::id()
+        ));
+        std::fs::write(&path, vec![b'x'; MAX_PROMPT_FILE_BYTES as usize + 1])
+            .expect("write oversize temp prompt");
+        let mut cli =
+            TuiCli::try_parse_from(["codex", "--prompt-file", path.to_str().expect("utf8 path")])
+                .expect("parse should succeed");
+
+        let err = resolve_prompt_file(&mut cli).expect_err("oversize file must error");
+        let _ = std::fs::remove_file(&path);
+        assert!(
+            err.to_string().contains("limit"),
+            "error should mention the size limit: {err}"
+        );
+        assert_eq!(
+            cli.prompt, None,
+            "oversize file must not populate the prompt"
+        );
+    }
+}

--- a/codex-rs/core-plugins/src/claude_loader.rs
+++ b/codex-rs/core-plugins/src/claude_loader.rs
@@ -1,0 +1,54 @@
+use crate::claude::enabled_claude_plugin_roots;
+use crate::config_layer_compat::base_user_home_dir;
+use crate::loader::load_plugin_from_root;
+use crate::store::PluginStore;
+use codex_config::ConfigLayerStack;
+use codex_config::types::McpServerConfig;
+use codex_config::types::PluginMcpServerConfig;
+use codex_core_skills::config_rules::SkillConfigRules;
+use codex_plugin::LoadedPlugin;
+use codex_protocol::protocol::Product;
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::path::PathBuf;
+
+pub(crate) async fn load_enabled_claude_plugins(
+    config_layer_stack: &ConfigLayerStack,
+    store: &PluginStore,
+    restriction_product: Option<Product>,
+    skill_config_rules: &SkillConfigRules,
+    configured_plugin_keys: &HashSet<String>,
+    plugin_hooks_enabled: bool,
+) -> Vec<LoadedPlugin<McpServerConfig>> {
+    let home_dir = claude_plugins_home_dir(config_layer_stack);
+    let mcp_server_policies: HashMap<String, PluginMcpServerConfig> = HashMap::new();
+    let mut plugins = Vec::new();
+
+    for claude_plugin in enabled_claude_plugin_roots(home_dir.as_deref()) {
+        let config_name = claude_plugin.plugin_id.as_key();
+        if configured_plugin_keys.contains(&config_name) {
+            continue;
+        }
+        let plugin_data_root = store.plugin_data_root(&claude_plugin.plugin_id);
+        plugins.push(
+            load_plugin_from_root(
+                config_name,
+                claude_plugin.source_path,
+                /*enabled*/ true,
+                &claude_plugin.plugin_id,
+                plugin_data_root,
+                restriction_product,
+                skill_config_rules,
+                &mcp_server_policies,
+                plugin_hooks_enabled,
+            )
+            .await,
+        );
+    }
+
+    plugins
+}
+
+fn claude_plugins_home_dir(config_layer_stack: &ConfigLayerStack) -> Option<PathBuf> {
+    base_user_home_dir(config_layer_stack)
+}

--- a/codex-rs/core-plugins/src/lib.rs
+++ b/codex-rs/core-plugins/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod claude;
+mod claude_loader;
 mod config_layer_compat;
 pub mod installed_marketplaces;
 pub mod loader;

--- a/codex-rs/core-plugins/src/loader.rs
+++ b/codex-rs/core-plugins/src/loader.rs
@@ -1,6 +1,5 @@
 use crate::OPENAI_CURATED_MARKETPLACE_NAME;
-use crate::claude::enabled_claude_plugin_roots;
-use crate::config_layer_compat::base_user_home_dir;
+use crate::claude_loader::load_enabled_claude_plugins;
 use crate::config_layer_compat::effective_user_config;
 use crate::manifest::PluginManifestHooks;
 use crate::manifest::PluginManifestPaths;
@@ -43,7 +42,6 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::fs;
 use std::path::Path;
-use std::path::PathBuf;
 use std::process::Command;
 use std::sync::Arc;
 use tempfile::TempDir;
@@ -145,26 +143,16 @@ pub async fn load_plugins_from_layer_stack(
         plugins.push(loaded_plugin);
     }
 
-    let home_dir = claude_plugins_home_dir(config_layer_stack);
-    let claude_mcp_server_policies: HashMap<String, PluginMcpServerConfig> = HashMap::new();
-    for claude_plugin in enabled_claude_plugin_roots(home_dir.as_deref()) {
-        let config_name = claude_plugin.plugin_id.as_key();
-        if configured_plugin_keys.contains(&config_name) {
-            continue;
-        }
-        let plugin_data_root = store.plugin_data_root(&claude_plugin.plugin_id);
-        let loaded_plugin = load_plugin_from_root(
-            config_name,
-            claude_plugin.source_path,
-            /*enabled*/ true,
-            &claude_plugin.plugin_id,
-            plugin_data_root,
-            restriction_product,
-            &skill_config_rules,
-            &claude_mcp_server_policies,
-            plugin_hooks_enabled,
-        )
-        .await;
+    for loaded_plugin in load_enabled_claude_plugins(
+        config_layer_stack,
+        store,
+        restriction_product,
+        &skill_config_rules,
+        &configured_plugin_keys,
+        plugin_hooks_enabled,
+    )
+    .await
+    {
         record_mcp_server_names(&loaded_plugin, &mut seen_mcp_server_names);
         plugins.push(loaded_plugin);
     }
@@ -205,10 +193,6 @@ pub fn remote_installed_plugins_to_config(
             ))
         })
         .collect()
-}
-
-fn claude_plugins_home_dir(config_layer_stack: &ConfigLayerStack) -> Option<PathBuf> {
-    base_user_home_dir(config_layer_stack)
 }
 
 fn record_mcp_server_names(
@@ -589,7 +573,7 @@ async fn load_plugin(
 }
 
 #[allow(clippy::too_many_arguments)]
-async fn load_plugin_from_root(
+pub(crate) async fn load_plugin_from_root(
     config_name: String,
     plugin_root: AbsolutePathBuf,
     enabled: bool,

--- a/codex-rs/core/src/tools/handlers/apply_patch.rs
+++ b/codex-rs/core/src/tools/handlers/apply_patch.rs
@@ -10,7 +10,6 @@ use crate::apply_patch;
 use crate::apply_patch::InternalApplyPatchInvocation;
 use crate::apply_patch::convert_apply_patch_to_protocol;
 use crate::function_tool::FunctionCallError;
-use crate::hook_runtime::run_file_changed_hooks;
 use crate::session::session::Session;
 use crate::session::turn_context::TurnContext;
 use crate::session::turn_context::TurnEnvironment;
@@ -23,6 +22,7 @@ use crate::tools::context::boxed_tool_output;
 use crate::tools::events::ToolEmitter;
 use crate::tools::events::ToolEventCtx;
 use crate::tools::handlers::apply_granted_turn_permissions;
+use crate::tools::handlers::apply_patch_file_changed::run_apply_patch_file_changed_hooks;
 use crate::tools::handlers::apply_patch_spec::create_apply_patch_freeform_tool;
 use crate::tools::handlers::resolve_tool_environment;
 use crate::tools::handlers::updated_hook_command;
@@ -417,11 +417,10 @@ impl ToolExecutor<ToolInvocation> for ApplyPatchHandler {
                             Some(&tracker),
                         );
                         let content = emitter.finish(event_ctx, out, delta.as_ref()).await?;
-                        run_file_changed_hooks(
+                        run_apply_patch_file_changed_hooks(
                             &session,
                             &turn,
                             call_id.clone(),
-                            "apply_patch".to_string(),
                             hook_changes,
                         )
                         .await;
@@ -577,11 +576,10 @@ pub(crate) async fn intercept_apply_patch(
                         tracker.as_ref().copied(),
                     );
                     let content = emitter.finish(event_ctx, out, delta.as_ref()).await?;
-                    run_file_changed_hooks(
+                    run_apply_patch_file_changed_hooks(
                         &session,
                         &turn,
                         call_id.to_string(),
-                        "apply_patch".to_string(),
                         hook_changes,
                     )
                     .await;

--- a/codex-rs/core/src/tools/handlers/apply_patch_file_changed.rs
+++ b/codex-rs/core/src/tools/handlers/apply_patch_file_changed.rs
@@ -1,0 +1,16 @@
+use crate::hook_runtime::run_file_changed_hooks;
+use crate::session::session::Session;
+use crate::session::turn_context::TurnContext;
+use codex_protocol::protocol::FileChange;
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+pub(super) async fn run_apply_patch_file_changed_hooks(
+    session: &Arc<Session>,
+    turn: &Arc<TurnContext>,
+    call_id: String,
+    changes: HashMap<PathBuf, FileChange>,
+) {
+    run_file_changed_hooks(session, turn, call_id, "apply_patch".to_string(), changes).await;
+}

--- a/codex-rs/core/src/tools/handlers/mod.rs
+++ b/codex-rs/core/src/tools/handlers/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod agent_jobs;
 pub(crate) mod agent_jobs_spec;
 pub(crate) mod apply_patch;
+mod apply_patch_file_changed;
 pub(crate) mod apply_patch_spec;
 mod dynamic;
 pub(crate) mod extension_tools;


### PR DESCRIPTION
## Summary
- move Claude-enabled plugin loading out of the core plugin loader into a leaf helper
- move --prompt-file resolution and focused tests out of cli/src/main.rs
- extract app-server process settings propagation and apply_patch FileChanged hook dispatch into small helpers
- keep upstream-hot files as stable call sites while preserving current behavior

## Conflict surfaces reduced
- core-plugins loader now has one Claude plugin call site instead of inline Claude settings/home-dir/plugin-root loading
- cli main no longer owns prompt-file file I/O, size limit handling, or tests
- app-server thread/config processors delegate settings-file and hook runtime propagation to a helper
- apply_patch handler delegates FileChanged hook tool-name dispatch to a leaf helper

## Tests
- ~/.cargo/bin/just fmt (Rust cargo fmt ran; Python SDK ruff step failed because openai-codex-cli-bin 0.131.0a4 has no wheel for this Linux platform)
- cargo test -p codex-core-plugins
- cargo test -p codex-cli prompt_file
- cargo test -p codex-core file_changed_runs_after_successful_apply_patch
- cargo test -p codex-core-plugins load_plugins_includes_claude_enabled_plugin_skills
- RUST_MIN_STACK=16777216 cargo test -p codex-app-server thread_start_inherits_settings_file_hooks_from_embedded_process

## Notes
- cargo test -p codex-core apply_patch was intentionally too broad for this change: 123 tests passed, 11 existing sandbox/approval cases failed with sandbox helper SIGABRT/path traversal or approval timeouts. The focused FileChanged apply_patch regression test passed.

Closes #63