### PR TITLE
Isolate config-layer compatibility adapters

### DIFF
--- a/codex-rs/core-plugins/src/config_layer_compat.rs
+++ b/codex-rs/core-plugins/src/config_layer_compat.rs
@@ -1,0 +1,145 @@
+use codex_app_server_protocol::ConfigLayerSource;
+use codex_config::ConfigLayerEntry;
+use codex_config::ConfigLayerStack;
+use codex_config::ConfigLayerStackOrdering;
+use codex_utils_absolute_path::AbsolutePathBuf;
+use std::path::Path;
+use std::path::PathBuf;
+use toml::Value;
+
+/// Returns the home directory paired with the base user config layer.
+///
+/// Claude compatibility uses this for `$HOME/.claude` discovery. It must stay
+/// anchored to the base user layer rather than the active user layer, because
+/// profile-v2 overlays may be stored under a different config file while still
+/// sharing the same Claude home.
+pub(crate) fn base_user_home_dir(config_layer_stack: &ConfigLayerStack) -> Option<PathBuf> {
+    let user_config_folders =
+        base_user_layers(config_layer_stack).filter_map(ConfigLayerEntry::config_folder);
+
+    home_dir_from_base_user_config_folders(user_config_folders)
+}
+
+/// Returns the merged config from enabled user layers only.
+///
+/// This is a local adapter for upstream profile-v2 APIs so plugin config reads
+/// keep using base user config on older branches and profile overlays after the
+/// daily rebase.
+pub(crate) fn effective_user_config(config_layer_stack: &ConfigLayerStack) -> Option<Value> {
+    let user_configs = base_user_layers(config_layer_stack).map(|layer| &layer.config);
+    merge_user_config_values(user_configs)
+}
+
+fn base_user_layers(
+    config_layer_stack: &ConfigLayerStack,
+) -> impl Iterator<Item = &ConfigLayerEntry> {
+    config_layer_stack
+        .get_layers(
+            ConfigLayerStackOrdering::LowestPrecedenceFirst,
+            /*include_disabled*/ false,
+        )
+        .into_iter()
+        .filter(|layer| matches!(&layer.name, ConfigLayerSource::User { .. }))
+}
+
+fn merge_user_config_values<'a>(
+    user_configs: impl IntoIterator<Item = &'a Value>,
+) -> Option<Value> {
+    let mut user_configs = user_configs.into_iter();
+    let mut merged = user_configs.next()?.clone();
+    for user_config in user_configs {
+        merge_toml_values(&mut merged, user_config);
+    }
+    Some(merged)
+}
+
+fn merge_toml_values(base: &mut Value, overlay: &Value) {
+    match (base, overlay) {
+        (Value::Table(base_table), Value::Table(overlay_table)) => {
+            for (key, value) in overlay_table {
+                if let Some(base_value) = base_table.get_mut(key) {
+                    merge_toml_values(base_value, value);
+                } else {
+                    base_table.insert(key.clone(), value.clone());
+                }
+            }
+        }
+        (base_value, overlay_value) => *base_value = overlay_value.clone(),
+    }
+}
+
+fn home_dir_from_base_user_config_folders(
+    user_config_folders: impl IntoIterator<Item = AbsolutePathBuf>,
+) -> Option<PathBuf> {
+    user_config_folders
+        .into_iter()
+        .next()
+        .and_then(|config_folder| config_folder.as_path().parent().map(Path::to_path_buf))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use codex_config::ConfigLayerStack;
+    use pretty_assertions::assert_eq;
+    use tempfile::tempdir;
+    use toml::Value;
+
+    #[test]
+    fn base_user_home_dir_uses_parent_of_user_config_folder() {
+        let home = tempdir().expect("tempdir");
+        let config_toml = AbsolutePathBuf::try_from(home.path().join(".codex/config.toml"))
+            .expect("absolute path");
+        let stack = ConfigLayerStack::default()
+            .with_user_config(&config_toml, Value::Table(toml::map::Map::new()));
+
+        assert_eq!(base_user_home_dir(&stack), Some(home.path().to_path_buf()));
+    }
+
+    #[test]
+    fn home_dir_from_base_user_config_folders_prefers_base_over_profile_overlay() {
+        let home = tempdir().expect("tempdir");
+        let profile_home = tempdir().expect("tempdir");
+        let base_config_folder =
+            AbsolutePathBuf::try_from(home.path().join(".codex")).expect("absolute path");
+        let profile_config_folder =
+            AbsolutePathBuf::try_from(profile_home.path().join(".codex")).expect("absolute path");
+
+        assert_eq!(
+            home_dir_from_base_user_config_folders([base_config_folder, profile_config_folder]),
+            Some(home.path().to_path_buf())
+        );
+    }
+
+    #[test]
+    fn merge_user_config_values_overlays_profile_config() {
+        let base = r#"
+[features]
+plugins = true
+
+[plugins."sample@test"]
+enabled = false
+"#;
+        let overlay = r#"
+[plugins."sample@test"]
+enabled = true
+"#;
+        let expected = r#"
+[features]
+plugins = true
+
+[plugins."sample@test"]
+enabled = true
+"#;
+
+        let merged = merge_user_config_values([
+            &toml::from_str::<Value>(base).expect("base toml"),
+            &toml::from_str::<Value>(overlay).expect("overlay toml"),
+        ]);
+
+        assert_eq!(
+            merged,
+            Some(toml::from_str::<Value>(expected).expect("expected toml"))
+        );
+    }
+}

--- a/codex-rs/core-plugins/src/installed_marketplaces.rs
+++ b/codex-rs/core-plugins/src/installed_marketplaces.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 use std::path::PathBuf;
 
+use crate::config_layer_compat::effective_user_config;
 use codex_config::ConfigLayerStack;
 use codex_plugin::validate_plugin_segment;
 use codex_utils_absolute_path::AbsolutePathBuf;
@@ -18,7 +19,7 @@ pub fn installed_marketplace_roots_from_layer_stack(
     config_layer_stack: &ConfigLayerStack,
     codex_home: &Path,
 ) -> Vec<AbsolutePathBuf> {
-    let Some(user_config) = config_layer_stack.effective_user_config() else {
+    let Some(user_config) = effective_user_config(config_layer_stack) else {
         return Vec::new();
     };
     let Some(marketplaces_value) = user_config.get("marketplaces") else {

--- a/codex-rs/core-plugins/src/lib.rs
+++ b/codex-rs/core-plugins/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod claude;
+mod config_layer_compat;
 pub mod installed_marketplaces;
 pub mod loader;
 mod manager;

--- a/codex-rs/core-plugins/src/loader.rs
+++ b/codex-rs/core-plugins/src/loader.rs
@@ -1,5 +1,7 @@
 use crate::OPENAI_CURATED_MARKETPLACE_NAME;
 use crate::claude::enabled_claude_plugin_roots;
+use crate::config_layer_compat::base_user_home_dir;
+use crate::config_layer_compat::effective_user_config;
 use crate::manifest::PluginManifestHooks;
 use crate::manifest::PluginManifestPaths;
 use crate::manifest::load_plugin_manifest;
@@ -206,10 +208,7 @@ pub fn remote_installed_plugins_to_config(
 }
 
 fn claude_plugins_home_dir(config_layer_stack: &ConfigLayerStack) -> Option<PathBuf> {
-    config_layer_stack
-        .get_active_user_layer()
-        .and_then(codex_config::ConfigLayerEntry::config_folder)
-        .and_then(|config_folder| config_folder.as_path().parent().map(Path::to_path_buf))
+    base_user_home_dir(config_layer_stack)
 }
 
 fn record_mcp_server_names(
@@ -420,7 +419,7 @@ fn refresh_non_curated_plugin_cache_with_mode(
 fn configured_plugins_from_stack(
     config_layer_stack: &ConfigLayerStack,
 ) -> HashMap<String, PluginConfig> {
-    let Some(user_config) = config_layer_stack.effective_user_config() else {
+    let Some(user_config) = effective_user_config(config_layer_stack) else {
         return HashMap::new();
     };
     configured_plugins_from_user_config_value(&user_config)

--- a/codex-rs/core-plugins/src/manager.rs
+++ b/codex-rs/core-plugins/src/manager.rs
@@ -1,6 +1,7 @@
 use super::PluginLoadOutcome;
 use super::startup_remote_sync::start_startup_remote_plugin_sync_once;
 use crate::OPENAI_CURATED_MARKETPLACE_NAME;
+use crate::config_layer_compat::effective_user_config;
 use crate::installed_marketplaces::installed_marketplace_roots_from_layer_stack;
 use crate::loader::configured_curated_plugin_ids_from_codex_home;
 use crate::loader::curated_plugin_cache_version;
@@ -1997,7 +1998,7 @@ pub(crate) fn configured_plugins_from_stack(
     config_layer_stack: &ConfigLayerStack,
 ) -> HashMap<String, PluginConfig> {
     // Plugin entries remain persisted user config only.
-    let Some(user_config) = config_layer_stack.effective_user_config() else {
+    let Some(user_config) = effective_user_config(config_layer_stack) else {
         return HashMap::new();
     };
     configured_plugins_from_user_config_value(&user_config)

--- a/codex-rs/core-plugins/src/marketplace_upgrade.rs
+++ b/codex-rs/core-plugins/src/marketplace_upgrade.rs
@@ -6,6 +6,7 @@ use self::activation::installed_marketplace_metadata_matches;
 use self::activation::write_installed_marketplace_metadata;
 use self::git::clone_git_source;
 use self::git::git_remote_revision;
+use crate::config_layer_compat::effective_user_config;
 use crate::marketplace::find_marketplace_manifest_path;
 use crate::marketplace::validate_marketplace_root;
 use codex_config::CONFIG_TOML_FILE;
@@ -109,7 +110,7 @@ fn marketplace_install_root(codex_home: &Path) -> PathBuf {
 fn configured_git_marketplaces(
     config_layer_stack: &ConfigLayerStack,
 ) -> Vec<ConfiguredGitMarketplace> {
-    let Some(user_config) = config_layer_stack.effective_user_config() else {
+    let Some(user_config) = effective_user_config(config_layer_stack) else {
         return Vec::new();
     };
     let Some(marketplaces_value) = user_config.get("marketplaces") else {


### PR DESCRIPTION
## Summary
- add a core-plugins config-layer compatibility adapter for user-layer config reads
- keep Claude plugin discovery anchored to the base user home instead of active profile overlay paths
- route plugin and marketplace config reads through the adapter to reduce future profile-v2 rebase churn

Fixes #62.

## Verification
- cargo test -p codex-core-plugins: 199 passed
- just fix -p codex-core-plugins: completed, no edits; existing warnings only
- git diff --check: passed
- cargo check --workspace --offline: passed
