### PR TITLE
Harden prompt-file handling on compat branch

### DIFF
--- a/codex-rs/cli/src/main.rs
+++ b/codex-rs/cli/src/main.rs
@@ -80,6 +80,7 @@ use codex_models_manager::manager::RefreshStrategy;
 use codex_protocol::protocol::AskForApproval;
 use codex_protocol::user_input::UserInput;
 use codex_terminal_detection::TerminalName;
+use prompt_file::normalize_prompt;
 use prompt_file::resolve_prompt_file;
 
 /// Codex CLI
@@ -1600,7 +1601,9 @@ async fn run_debug_prompt_input_command(
     mut interactive: TuiCli,
     arg0_paths: Arg0DispatchPaths,
 ) -> anyhow::Result<()> {
-    resolve_prompt_file(&mut interactive)?;
+    if cmd.prompt.is_none() {
+        resolve_prompt_file(&mut interactive)?;
+    }
     let loader_overrides = loader_overrides_for_profile(interactive.config_profile_v2.as_ref())?;
     let shared = interactive.shared.into_inner();
     let mut cli_kv_overrides = root_config_overrides
@@ -1940,8 +1943,7 @@ async fn run_interactive_tui(
     }
     if let Some(prompt) = interactive.prompt.take() {
         // Normalize CRLF/CR to LF so CLI-provided text can't leak `\r` into TUI state.
-        // Runs after resolve_prompt_file, so file-sourced prompts are normalized too.
-        interactive.prompt = Some(prompt.replace("\r\n", "\n").replace('\r', "\n"));
+        interactive.prompt = Some(normalize_prompt(prompt));
     }
 
     let terminal_info = codex_terminal_detection::terminal_info();
@@ -2124,13 +2126,11 @@ fn merge_interactive_cli_flags(interactive: &mut TuiCli, subcommand_cli: TuiCli)
     }
     if let Some(prompt) = prompt {
         // Normalize CRLF/CR to LF so CLI-provided text can't leak `\r` into TUI state.
-        interactive.prompt = Some(prompt.replace("\r\n", "\n").replace('\r', "\n"));
+        interactive.prompt = Some(normalize_prompt(prompt));
+        interactive.prompt_file = None;
     }
-    // Carry `--prompt-file` from a subcommand-scoped CLI (e.g. `codex resume
-    // --prompt-file X`) into the merged interactive CLI; `..` above would
-    // otherwise silently drop it. Resolution into `prompt` happens later in
-    // `run_interactive_tui`.
     if let Some(prompt_file) = prompt_file {
+        interactive.prompt = None;
         interactive.prompt_file = Some(prompt_file);
     }
 
@@ -3417,5 +3417,96 @@ mod tests {
             Some(std::path::Path::new("/tmp/sub.txt")),
             "subcommand --prompt-file must survive the merge",
         );
+        assert_eq!(base.prompt, None);
+    }
+
+    #[test]
+    fn merge_interactive_cli_flags_prompt_file_clears_existing_prompt() {
+        let mut base = MultitoolCli::try_parse_from(["codex", "root prompt"])
+            .expect("parse should succeed")
+            .interactive;
+        let subcommand = MultitoolCli::try_parse_from(["codex", "--prompt-file", "/tmp/sub.txt"])
+            .expect("parse should succeed")
+            .interactive;
+
+        merge_interactive_cli_flags(&mut base, subcommand);
+
+        assert_eq!(
+            base.prompt_file.as_deref(),
+            Some(std::path::Path::new("/tmp/sub.txt")),
+        );
+        assert_eq!(base.prompt, None);
+    }
+
+    #[test]
+    fn merge_interactive_cli_flags_prompt_clears_existing_prompt_file() {
+        let mut base = MultitoolCli::try_parse_from(["codex", "--prompt-file", "/tmp/root.txt"])
+            .expect("parse should succeed")
+            .interactive;
+        let subcommand = MultitoolCli::try_parse_from(["codex", "sub\r\nprompt"])
+            .expect("parse should succeed")
+            .interactive;
+
+        merge_interactive_cli_flags(&mut base, subcommand);
+
+        assert_eq!(base.prompt.as_deref(), Some("sub\nprompt"));
+        assert_eq!(base.prompt_file, None);
+    }
+
+    #[tokio::test]
+    async fn interactive_tui_returns_fatal_for_missing_prompt_file() {
+        let interactive = MultitoolCli::try_parse_from([
+            "codex",
+            "--prompt-file",
+            "/nonexistent/codex-prompt-file/missing.txt",
+        ])
+        .expect("parse should succeed")
+        .interactive;
+
+        let exit_info = run_interactive_tui(interactive, None, None, Arg0DispatchPaths::default())
+            .await
+            .expect("missing prompt file returns a fatal exit");
+
+        let ExitReason::Fatal(message) = exit_info.exit_reason else {
+            panic!("expected fatal exit");
+        };
+        assert!(
+            message.contains("--prompt-file"),
+            "error should name the flag: {message}"
+        );
+    }
+
+    #[tokio::test]
+    async fn debug_prompt_input_prompt_takes_precedence_over_missing_root_prompt_file() {
+        let cli = MultitoolCli::try_parse_from([
+            "codex",
+            "--prompt-file",
+            "/nonexistent/codex-prompt-file/missing.txt",
+            "debug",
+            "prompt-input",
+            "hi",
+        ])
+        .expect("parse should succeed");
+        let MultitoolCli {
+            interactive,
+            config_overrides: root_overrides,
+            subcommand,
+            feature_toggles: _,
+            remote: _,
+        } = cli;
+        let Some(Subcommand::Debug(DebugCommand {
+            subcommand: DebugSubcommand::PromptInput(cmd),
+        })) = subcommand
+        else {
+            panic!("expected debug prompt-input subcommand");
+        };
+
+        let arg0_paths = Arg0DispatchPaths {
+            codex_self_exe: Some(std::env::current_exe().expect("current exe")),
+            ..Default::default()
+        };
+        run_debug_prompt_input_command(cmd, root_overrides, interactive, arg0_paths)
+            .await
+            .expect("subcommand prompt should not read lower-priority root prompt file");
     }
 }

--- a/codex-rs/cli/src/prompt_file.rs
+++ b/codex-rs/cli/src/prompt_file.rs
@@ -1,50 +1,67 @@
 use codex_tui::Cli as TuiCli;
+use std::io::Read;
 
-/// Upper bound on `--prompt-file` size. The positional `PROMPT` argument is
-/// implicitly capped by `ARG_MAX` (~2 MiB usable); `--prompt-file` removes that
-/// ceiling, so a hard limit is reintroduced here to keep an accidental log or
-/// binary file from allocating unbounded memory at startup and injecting a
-/// runaway initial context item. 10 MiB is far above any real task prompt
-/// (which cannot usefully exceed the model context window) yet well below
-/// "pointed at the wrong file" territory.
+// Keep prompt-file reads bounded so accidentally passing a large log or binary
+// cannot allocate unbounded memory before the TUI starts.
 const MAX_PROMPT_FILE_BYTES: u64 = 10 * 1024 * 1024;
 
-/// Fold `--prompt-file` into the positional `prompt` slot. After this runs the
-/// file-sourced prompt is indistinguishable from a positional CLI prompt: it
-/// sets `skip_update_prompt` and is submitted internally via
-/// `create_initial_user_message`, so an orchestrator launching Codex in a PTY
-/// can deliver the initial prompt without a terminal-input race.
-///
-/// `--prompt-file` and a positional `PROMPT` are mutually exclusive at the clap
-/// layer; the `prompt.is_some()` guard only matters if the two ever arrive
-/// through separate arg matchers (base CLI vs. a flattened subcommand).
-///
-/// The file size is checked against [`MAX_PROMPT_FILE_BYTES`] before it is read,
-/// so an oversized file is rejected rather than read into memory.
+pub(crate) fn normalize_prompt(prompt: String) -> String {
+    prompt.replace("\r\n", "\n").replace('\r', "\n")
+}
+
 pub(crate) fn resolve_prompt_file(interactive: &mut TuiCli) -> std::io::Result<()> {
     if interactive.prompt.is_some() {
         return Ok(());
     }
-    if let Some(path) = interactive.prompt_file.take() {
-        let read_err = |e: std::io::Error| {
-            std::io::Error::new(
-                e.kind(),
-                format!("failed to read --prompt-file {}: {e}", path.display()),
-            )
-        };
-        let len = std::fs::metadata(&path).map_err(&read_err)?.len();
-        if len > MAX_PROMPT_FILE_BYTES {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                format!(
-                    "--prompt-file {} is {len} bytes, over the {MAX_PROMPT_FILE_BYTES}-byte limit",
-                    path.display(),
-                ),
-            ));
-        }
-        let text = std::fs::read_to_string(&path).map_err(&read_err)?;
-        interactive.prompt = Some(text);
+
+    let Some(path) = interactive.prompt_file.take() else {
+        return Ok(());
+    };
+
+    let read_err = |err: std::io::Error| {
+        std::io::Error::new(
+            err.kind(),
+            format!("failed to read --prompt-file {}: {err}", path.display()),
+        )
+    };
+    let metadata = std::fs::metadata(&path).map_err(&read_err)?;
+    if !metadata.is_file() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("--prompt-file {} is not a regular file", path.display()),
+        ));
     }
+
+    let file = std::fs::File::open(&path).map_err(&read_err)?;
+    let metadata = file.metadata().map_err(&read_err)?;
+    if !metadata.is_file() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("--prompt-file {} is not a regular file", path.display()),
+        ));
+    }
+
+    let mut bytes = Vec::new();
+    file.take(MAX_PROMPT_FILE_BYTES + 1)
+        .read_to_end(&mut bytes)
+        .map_err(&read_err)?;
+    if bytes.len() as u64 > MAX_PROMPT_FILE_BYTES {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!(
+                "--prompt-file {} is over the {MAX_PROMPT_FILE_BYTES}-byte limit",
+                path.display()
+            ),
+        ));
+    }
+
+    let text = String::from_utf8(bytes).map_err(|err| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("failed to read --prompt-file {}: {err}", path.display()),
+        )
+    })?;
+    interactive.prompt = Some(normalize_prompt(text));
     Ok(())
 }
 
@@ -52,35 +69,39 @@ pub(crate) fn resolve_prompt_file(interactive: &mut TuiCli) -> std::io::Result<(
 mod tests {
     use super::*;
     use clap::Parser;
+    use pretty_assertions::assert_eq;
+    use std::io::Write;
+    use std::path::Path;
 
-    #[test]
-    fn reads_file_into_prompt() {
-        let path = std::env::temp_dir().join(format!(
-            "codex-prompt-file-resolve-{}.txt",
-            std::process::id()
-        ));
-        std::fs::write(&path, "do the thing").expect("write temp prompt");
-        let mut cli =
-            TuiCli::try_parse_from(["codex", "--prompt-file", path.to_str().expect("utf8 path")])
-                .expect("parse should succeed");
-
-        resolve_prompt_file(&mut cli).expect("resolve should succeed");
-
-        assert_eq!(cli.prompt.as_deref(), Some("do the thing"));
-        assert_eq!(cli.prompt_file, None);
-        let _ = std::fs::remove_file(&path);
+    fn cli_with_prompt_file(path: &Path) -> TuiCli {
+        TuiCli::try_parse_from(["codex", "--prompt-file", path.to_str().expect("utf-8 path")])
+            .expect("parse should succeed")
     }
 
     #[test]
-    fn missing_file_is_error() {
+    fn reads_utf8_file_into_prompt() {
+        let mut file = tempfile::NamedTempFile::new().expect("create temp prompt file");
+        write!(file, "first line\nsecond line").expect("write temp prompt");
+        let mut cli = cli_with_prompt_file(file.path());
+
+        resolve_prompt_file(&mut cli).expect("resolve should succeed");
+
+        assert_eq!(cli.prompt.as_deref(), Some("first line\nsecond line"));
+        assert_eq!(cli.prompt_file, None);
+    }
+
+    #[test]
+    fn rejects_missing_file() {
         let mut cli = TuiCli::try_parse_from([
             "codex",
             "--prompt-file",
-            "/nonexistent/codex-prompt-file/zzz.txt",
+            "/nonexistent/codex-prompt-file/missing.txt",
         ])
         .expect("parse should succeed");
 
         let err = resolve_prompt_file(&mut cli).expect_err("missing file must error");
+
+        assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
         assert!(
             err.to_string().contains("--prompt-file"),
             "error should name the flag: {err}"
@@ -88,26 +109,65 @@ mod tests {
     }
 
     #[test]
-    fn rejects_oversize_file() {
-        let path = std::env::temp_dir().join(format!(
-            "codex-prompt-file-oversize-{}.txt",
-            std::process::id()
-        ));
-        std::fs::write(&path, vec![b'x'; MAX_PROMPT_FILE_BYTES as usize + 1])
-            .expect("write oversize temp prompt");
-        let mut cli =
-            TuiCli::try_parse_from(["codex", "--prompt-file", path.to_str().expect("utf8 path")])
-                .expect("parse should succeed");
+    fn rejects_oversized_file() {
+        let file = tempfile::NamedTempFile::new().expect("create temp prompt file");
+        file.as_file()
+            .set_len(MAX_PROMPT_FILE_BYTES + 1)
+            .expect("size temp prompt file");
+        let mut cli = cli_with_prompt_file(file.path());
 
-        let err = resolve_prompt_file(&mut cli).expect_err("oversize file must error");
-        let _ = std::fs::remove_file(&path);
+        let err = resolve_prompt_file(&mut cli).expect_err("oversized file must error");
+
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+        assert_eq!(cli.prompt, None);
         assert!(
             err.to_string().contains("limit"),
             "error should mention the size limit: {err}"
         );
+    }
+
+    #[test]
+    fn rejects_non_regular_file() {
+        let dir = tempfile::tempdir().expect("create temp prompt dir");
+        let mut cli = cli_with_prompt_file(dir.path());
+
+        let err = resolve_prompt_file(&mut cli).expect_err("directory must error");
+
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+        assert!(
+            err.to_string().contains("regular file"),
+            "error should mention regular file requirement: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_utf8() {
+        let mut file = tempfile::NamedTempFile::new().expect("create temp prompt file");
+        file.write_all(&[0xff, 0xfe, 0xfd])
+            .expect("write invalid utf-8");
+        let mut cli = cli_with_prompt_file(file.path());
+
+        let err = resolve_prompt_file(&mut cli).expect_err("invalid utf-8 must error");
+
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+        assert!(
+            err.to_string().contains("--prompt-file"),
+            "error should name the flag: {err}"
+        );
+    }
+
+    #[test]
+    fn normalizes_line_endings_like_positional_prompt() {
+        let mut file = tempfile::NamedTempFile::new().expect("create temp prompt file");
+        write!(file, "a\r\nb\rc").expect("write temp prompt");
+        let mut cli = cli_with_prompt_file(file.path());
+
+        resolve_prompt_file(&mut cli).expect("resolve should succeed");
+
+        assert_eq!(cli.prompt.as_deref(), Some("a\nb\nc"));
         assert_eq!(
-            cli.prompt, None,
-            "oversize file must not populate the prompt"
+            normalize_prompt("a\r\nb\rc".to_string()),
+            "a\nb\nc".to_string()
         );
     }
 }

--- a/codex-rs/tui/src/cli.rs
+++ b/codex-rs/tui/src/cli.rs
@@ -12,10 +12,7 @@ pub struct Cli {
     #[arg(value_name = "PROMPT", value_hint = clap::ValueHint::Other)]
     pub prompt: Option<String>,
 
-    /// Read the initial user prompt from a file instead of the positional
-    /// PROMPT argument. The path is tiny in argv (no ARG_MAX limit) and is
-    /// read at startup, so an orchestrator launching Codex in a PTY can
-    /// deliver the prompt without a terminal-input race.
+    /// Read the initial user prompt from a UTF-8 encoded file.
     #[arg(
         long = "prompt-file",
         value_name = "PATH",


### PR DESCRIPTION
## Summary
- port the upstreamable `--prompt-file` hardening onto `feat/claude-compat`
- bound reads by bytes, reject non-regular paths before opening, and validate UTF-8
- normalize file-sourced prompts consistently and preserve prompt/prompt-file precedence in merged CLI flags
- keep help text product-neutral

## Testing
- `~/.cargo/bin/just fmt` (Rust formatting ran, then Python SDK formatter failed because `openai-codex-cli-bin==0.131.0a4` has no compatible Linux wheel)
- `rustfmt --edition 2024 codex-rs/cli/src/main.rs codex-rs/cli/src/prompt_file.rs codex-rs/tui/src/cli.rs --config imports_granularity=Item` (completed with stable-toolchain warning for nightly-only imports_granularity)
- `cargo test -p codex-cli prompt`
- `cargo test -p codex-cli`
- `cargo build -p codex-cli`
- `cargo clippy -p codex-cli --tests --fix --allow-dirty`
- `git diff --check`

Review notes:
- Pre-PR reviewers found and I fixed the unrelated formatting churn, missing size-limit rationale, FIFO blocking edge case, and missing merge/normalization coverage.
- `cargo test -p codex-tui` was not rerun for this compat port; earlier in #68 it was blocked by an unrelated reproducible stack overflow in `app::tests::open_agent_picker_prunes_terminal_metadata_only_threads`.