### PR TITLE
sync: merge upstream/main into feat/claude-compat (2026-05-26)

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -2248,6 +2248,7 @@ dependencies = [
  "codex-protocol",
  "codex-responses-api-proxy",
  "codex-rmcp-client",
+ "codex-rollout",
  "codex-rollout-trace",
  "codex-sandboxing",
  "codex-state",

--- a/codex-rs/app-server-client/src/lib.rs
+++ b/codex-rs/app-server-client/src/lib.rs
@@ -1122,7 +1122,9 @@ mod tests {
             websocket,
             JSONRPCMessage::Response(JSONRPCResponse {
                 id: request.id,
-                result: serde_json::json!({}),
+                result: serde_json::json!({
+                    "userAgent": "codex_cli_rs/9.8.7-test (Test OS; x86_64) rust",
+                }),
             }),
         )
         .await;
@@ -1457,6 +1459,7 @@ mod tests {
             .await
             .expect("remote client should connect");
 
+        assert_eq!(client.server_version(), Some("9.8.7-test"));
         let response: GetAccountResponse = client
             .request_typed(ClientRequest::GetAccount {
                 request_id: RequestId::Integer(1),

--- a/codex-rs/app-server-client/src/remote.rs
+++ b/codex-rs/app-server-client/src/remote.rs
@@ -150,6 +150,7 @@ pub struct RemoteAppServerClient {
     command_tx: mpsc::Sender<RemoteClientCommand>,
     event_rx: mpsc::UnboundedReceiver<AppServerEvent>,
     pending_events: VecDeque<AppServerEvent>,
+    server_version: Option<String>,
     worker_handle: tokio::task::JoinHandle<()>,
 }
 
@@ -180,6 +181,10 @@ impl RemoteAppServerClient {
         }
     }
 
+    pub fn server_version(&self) -> Option<&str> {
+        self.server_version.as_deref()
+    }
+
     async fn connect_with_stream<S>(
         channel_capacity: usize,
         endpoint: String,
@@ -190,7 +195,7 @@ impl RemoteAppServerClient {
         S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
     {
         let mut stream = stream;
-        let pending_events = initialize_remote_connection(
+        let (pending_events, server_version) = initialize_remote_connection(
             &mut stream,
             &endpoint,
             initialize_params,
@@ -466,6 +471,7 @@ impl RemoteAppServerClient {
             command_tx,
             event_rx,
             pending_events: pending_events.into(),
+            server_version,
             worker_handle,
         })
     }
@@ -606,6 +612,7 @@ impl RemoteAppServerClient {
             command_tx,
             event_rx,
             pending_events: _pending_events,
+            server_version: _server_version,
             worker_handle,
         } = self;
         let mut worker_handle = worker_handle;
@@ -793,12 +800,13 @@ async fn initialize_remote_connection<S>(
     endpoint: &str,
     params: InitializeParams,
     initialize_timeout: Duration,
-) -> IoResult<Vec<AppServerEvent>>
+) -> IoResult<(Vec<AppServerEvent>, Option<String>)>
 where
     S: AsyncRead + AsyncWrite + Unpin,
 {
     let initialize_request_id = RequestId::String("initialize".to_string());
     let mut pending_events = Vec::new();
+    let mut server_version = None;
     write_jsonrpc_message(
         stream,
         JSONRPCMessage::Request(jsonrpc_request_from_client_request(
@@ -822,6 +830,14 @@ where
                     })?;
                     match message {
                         JSONRPCMessage::Response(response) if response.id == initialize_request_id => {
+                            server_version = response
+                                .result
+                                .get("userAgent")
+                                .and_then(serde_json::Value::as_str)
+                                .and_then(|user_agent| {
+                                    let (_, rest) = user_agent.split_once('/')?;
+                                    rest.split_whitespace().next().map(str::to_string)
+                                });
                             break Ok(());
                         }
                         JSONRPCMessage::Error(error) if error.id == initialize_request_id => {
@@ -913,7 +929,7 @@ where
     )
     .await?;
 
-    Ok(pending_events)
+    Ok((pending_events, server_version))
 }
 
 fn app_server_event_from_notification(notification: JSONRPCNotification) -> Option<AppServerEvent> {
@@ -1007,6 +1023,7 @@ mod tests {
             command_tx,
             event_rx,
             pending_events: VecDeque::new(),
+            server_version: None,
             worker_handle,
         };
 

--- a/codex-rs/app-server-daemon/src/lib.rs
+++ b/codex-rs/app-server-daemon/src/lib.rs
@@ -74,6 +74,12 @@ pub struct BootstrapOptions {
     pub remote_control_enabled: bool,
 }
 
+/// Passively probes an existing app-server socket and returns its reported
+/// app-server version.
+pub async fn probe_app_server_version(socket_path: &Path) -> Result<String> {
+    Ok(client::probe(socket_path).await?.app_server_version)
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub enum BootstrapStatus {

--- a/codex-rs/app-server/src/config_manager.rs
+++ b/codex-rs/app-server/src/config_manager.rs
@@ -216,15 +216,23 @@ impl ConfigManager {
         &self,
         cli_overrides: &[(String, TomlValue)],
         request_overrides: Option<HashMap<String, serde_json::Value>>,
-        typesafe_overrides: ConfigOverrides,
+        mut typesafe_overrides: ConfigOverrides,
         fallback_cwd: Option<PathBuf>,
     ) -> std::io::Result<Config> {
+        let mut request_overrides = request_overrides.unwrap_or_default();
+        if let Some(value) = request_overrides.remove("bypass_hook_trust") {
+            typesafe_overrides.bypass_hook_trust = Some(value.as_bool().ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "`bypass_hook_trust` override must be a boolean",
+                )
+            })?);
+        }
         let merged_cli_overrides = cli_overrides
             .iter()
             .cloned()
             .chain(
                 request_overrides
-                    .unwrap_or_default()
                     .into_iter()
                     .map(|(key, value)| (key, json_to_toml(value))),
             )

--- a/codex-rs/app-server/src/request_processors/thread_processor_tests.rs
+++ b/codex-rs/app-server/src/request_processors/thread_processor_tests.rs
@@ -610,6 +610,7 @@ mod thread_processor_behavior_tests {
                 Some(HashMap::from([
                     ("model_provider".to_string(), json!("request")),
                     ("features.plugins".to_string(), json!(true)),
+                    ("bypass_hook_trust".to_string(), json!(true)),
                     (
                         "model_providers.session".to_string(),
                         json!({
@@ -626,6 +627,7 @@ mod thread_processor_behavior_tests {
         assert_eq!(config.model_provider_id, "session");
         assert_eq!(config.model_provider, session_provider);
         assert!(!config.features.enabled(Feature::Plugins));
+        assert!(config.bypass_hook_trust);
         Ok(())
     }
 

--- a/codex-rs/cli/Cargo.toml
+++ b/codex-rs/cli/Cargo.toml
@@ -49,6 +49,7 @@ codex-plugin = { workspace = true }
 codex-protocol = { workspace = true }
 codex-responses-api-proxy = { workspace = true }
 codex-rmcp-client = { workspace = true }
+codex-rollout = { workspace = true }
 codex-rollout-trace = { workspace = true }
 codex-sandboxing = { workspace = true }
 codex-state = { workspace = true }

--- a/codex-rs/cli/src/doctor.rs
+++ b/codex-rs/cli/src/doctor.rs
@@ -71,6 +71,7 @@ mod output;
 mod progress;
 mod runtime;
 mod system;
+mod thread_inventory;
 mod title;
 mod updates;
 
@@ -84,6 +85,7 @@ use progress::doctor_progress;
 use runtime::runtime_check;
 use runtime::search_check;
 use system::system_check;
+use thread_inventory::thread_inventory_check;
 use title::terminal_title_check;
 use updates::updates_check;
 
@@ -362,6 +364,7 @@ async fn build_report(
                 git_check,
                 terminal_title_check,
                 state_check,
+                thread_inventory_check,
                 background_server_check,
                 reachability_check,
             ) = tokio::join!(
@@ -393,6 +396,11 @@ async fn build_report(
                 },
                 run_async_check("state", progress.clone(), state_check(config)),
                 run_async_check(
+                    "thread inventory",
+                    progress.clone(),
+                    thread_inventory_check(config),
+                ),
+                run_async_check(
                     "app-server",
                     progress.clone(),
                     background_server_check(config)
@@ -415,6 +423,7 @@ async fn build_report(
                 git_check,
                 terminal_title_check,
                 state_check,
+                thread_inventory_check,
                 background_server_check,
                 reachability_check,
             ]);

--- a/codex-rs/cli/src/doctor.rs
+++ b/codex-rs/cli/src/doctor.rs
@@ -392,11 +392,11 @@ async fn build_report(
                     })
                 },
                 run_async_check("state", progress.clone(), state_check(config)),
-                async {
-                    run_sync_check("app-server", progress.clone(), || {
-                        background_server_check(config)
-                    })
-                },
+                run_async_check(
+                    "app-server",
+                    progress.clone(),
+                    background_server_check(config)
+                ),
                 run_async_check(
                     "provider reachability",
                     progress.clone(),

--- a/codex-rs/cli/src/doctor/background.rs
+++ b/codex-rs/cli/src/doctor/background.rs
@@ -2,7 +2,7 @@
 //!
 //! The background-server check is deliberately passive. It reads the daemon
 //! state directory, PID files, settings file, and control socket path, then
-//! attempts only a local socket connection when a socket already exists. That
+//! attempts only a bounded initialize probe when a socket already exists. That
 //! keeps doctor safe to run while the user is debugging startup or update-loop
 //! issues.
 
@@ -13,6 +13,7 @@ use codex_core::config::Config;
 use super::CheckStatus;
 use super::DoctorCheck;
 
+const MAX_PROBE_ERROR_CHARS: usize = 120;
 const STATE_DIR_NAME: &str = "app-server-daemon";
 const SETTINGS_FILE_NAME: &str = "settings.json";
 const PID_FILE_NAME: &str = "app-server.pid";
@@ -23,7 +24,7 @@ const UPDATE_PID_FILE_NAME: &str = "app-server-updater.pid";
 /// Missing files are expected for the ephemeral/not-running case and should not
 /// be treated as failures. A stale socket is a warning because it can explain
 /// client connection problems without proving the daemon itself is broken.
-pub(super) fn background_server_check(config: &Config) -> DoctorCheck {
+pub(super) async fn background_server_check(config: &Config) -> DoctorCheck {
     let mut details = Vec::new();
     let state_dir = config.codex_home.join(STATE_DIR_NAME);
     details.push(format!("daemon state dir: {}", state_dir.display()));
@@ -54,8 +55,11 @@ pub(super) fn background_server_check(config: &Config) -> DoctorCheck {
     };
 
     details.push(format!("control socket: {}", socket_path.display()));
-    let status = socket_status(socket_path.as_path());
+    let status = socket_status(socket_path.as_path()).await;
     details.push(format!("status: {}", status.detail_label()));
+    if let Some(version_detail) = status.app_server_version_detail() {
+        details.push(version_detail);
+    }
     details.push(format!("mode: {}", server_mode(&state_dir)));
 
     let mut check = DoctorCheck::new(
@@ -94,57 +98,162 @@ fn server_mode(state_dir: &Path) -> &'static str {
     }
 }
 
-#[derive(Clone, Copy)]
 enum SocketStatus {
     NotRunning,
-    Running,
-    #[cfg(unix)]
-    StaleOrUnreachable,
+    Running(String),
+    StaleOrUnreachable(String),
 }
 
 impl SocketStatus {
-    fn check_status(self) -> CheckStatus {
+    fn check_status(&self) -> CheckStatus {
         match self {
-            Self::NotRunning | Self::Running => CheckStatus::Ok,
-            #[cfg(unix)]
-            Self::StaleOrUnreachable => CheckStatus::Warning,
+            Self::NotRunning | Self::Running(_) => CheckStatus::Ok,
+            Self::StaleOrUnreachable(_) => CheckStatus::Warning,
         }
     }
 
-    fn summary(self) -> &'static str {
+    fn summary(&self) -> &'static str {
         match self {
             Self::NotRunning => "background server is not running",
-            Self::Running => "background server is running",
-            #[cfg(unix)]
-            Self::StaleOrUnreachable => "background server socket is stale or unreachable",
+            Self::Running(_) => "background server is running",
+            Self::StaleOrUnreachable(_) => "background server socket is stale or unreachable",
         }
     }
 
-    fn detail_label(self) -> &'static str {
+    fn detail_label(&self) -> &'static str {
         match self {
             Self::NotRunning => "not running",
-            Self::Running => "running",
-            #[cfg(unix)]
-            Self::StaleOrUnreachable => "stale or unreachable",
+            Self::Running(_) => "running",
+            Self::StaleOrUnreachable(_) => "stale or unreachable",
+        }
+    }
+
+    fn app_server_version_detail(&self) -> Option<String> {
+        match self {
+            Self::NotRunning => None,
+            Self::Running(app_server_version) => {
+                Some(format!("app-server version: {app_server_version}"))
+            }
+            Self::StaleOrUnreachable(error) => {
+                Some(format!("app-server version: unavailable ({error})"))
+            }
         }
     }
 }
 
-fn socket_status(socket_path: &Path) -> SocketStatus {
+async fn socket_status(socket_path: &Path) -> SocketStatus {
     if !socket_path.exists() {
         return SocketStatus::NotRunning;
     }
 
-    #[cfg(unix)]
-    {
-        match std::os::unix::net::UnixStream::connect(socket_path) {
-            Ok(_) => SocketStatus::Running,
-            Err(_) => SocketStatus::StaleOrUnreachable,
-        }
+    match codex_app_server_daemon::probe_app_server_version(socket_path).await {
+        Ok(app_server_version) => SocketStatus::Running(app_server_version),
+        Err(err) => SocketStatus::StaleOrUnreachable(concise_probe_error(&err, socket_path)),
+    }
+}
+
+fn concise_probe_error(err: &anyhow::Error, socket_path: &Path) -> String {
+    let socket_path = socket_path.display().to_string();
+    let message = err
+        .to_string()
+        .replace(&socket_path, "control socket")
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
+    if message.is_empty() {
+        return "unknown error".to_string();
+    }
+    let mut chars = message.chars();
+    let truncated = chars
+        .by_ref()
+        .take(MAX_PROBE_ERROR_CHARS)
+        .collect::<String>();
+    if chars.next().is_some() {
+        format!("{truncated}...")
+    } else {
+        message
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use codex_core::config::ConfigBuilder;
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+
+    async fn test_config(codex_home: PathBuf) -> Config {
+        ConfigBuilder::default()
+            .codex_home(codex_home)
+            .build()
+            .await
+            .expect("config")
     }
 
-    #[cfg(not(unix))]
-    {
-        SocketStatus::Running
+    fn create_socket_placeholder(config: &Config) {
+        let socket_path = codex_app_server::app_server_control_socket_path(&config.codex_home)
+            .expect("socket path");
+        std::fs::create_dir_all(socket_path.parent().expect("socket parent"))
+            .expect("create socket dir");
+        std::fs::write(socket_path, "").expect("create socket placeholder");
+    }
+
+    #[tokio::test]
+    async fn not_running_background_server_stays_ok_without_version() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let config = test_config(temp.path().to_path_buf()).await;
+
+        let check = background_server_check(&config).await;
+
+        assert_eq!(check.status, CheckStatus::Ok);
+        assert_eq!(check.summary, "background server is not running");
+        assert!(check.details.contains(&"status: not running".to_string()));
+        assert!(
+            !check
+                .details
+                .iter()
+                .any(|detail| detail.starts_with("app-server version:"))
+        );
+    }
+
+    #[test]
+    fn running_background_server_reports_app_server_version() {
+        let status = SocketStatus::Running("1.2.3".to_string());
+
+        assert_eq!(status.check_status(), CheckStatus::Ok);
+        assert_eq!(status.summary(), "background server is running");
+        assert_eq!(status.detail_label(), "running");
+        assert_eq!(
+            status.app_server_version_detail(),
+            Some("app-server version: 1.2.3".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn failed_version_probe_reports_unavailable() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let config = test_config(temp.path().to_path_buf()).await;
+        create_socket_placeholder(&config);
+
+        let check = background_server_check(&config).await;
+
+        assert_eq!(check.status, CheckStatus::Warning);
+        assert_eq!(
+            check.summary,
+            "background server socket is stale or unreachable"
+        );
+        assert!(
+            check
+                .details
+                .contains(&"status: stale or unreachable".to_string())
+        );
+        assert!(
+            check
+                .details
+                .iter()
+                .any(|detail| detail.starts_with("app-server version: unavailable ("))
+        );
     }
 }

--- a/codex-rs/cli/src/doctor/output.rs
+++ b/codex-rs/cli/src/doctor/output.rs
@@ -27,6 +27,7 @@ const GROUPS: &[OutputGroup] = &[
         title: "Environment",
         keys: &[
             "system", "runtime", "install", "search", "git", "terminal", "title", "state",
+            "threads",
         ],
     },
     OutputGroup {
@@ -1338,6 +1339,28 @@ Run codex doctor without --summary for detailed diagnostics.
             "─".repeat(SEPARATOR_WIDTH)
         );
         assert_eq!(rendered, expected);
+    }
+
+    #[test]
+    fn render_human_report_includes_threads_row_in_environment() {
+        let mut report = sample_report();
+        report.checks.push(DoctorCheck::new(
+            "state.rollout_db_parity",
+            "threads",
+            CheckStatus::Warning,
+            "rollout files and state DB thread inventory differ",
+        ));
+
+        let rendered = render_human_report(&report, summary_no_color_unicode_options());
+
+        let threads_line = rendered
+            .lines()
+            .find(|line| line.contains("threads"))
+            .expect("threads row should be rendered");
+        assert!(
+            threads_line.contains("rollout files and state DB thread inventory differ"),
+            "{threads_line}"
+        );
     }
 
     #[test]

--- a/codex-rs/cli/src/doctor/thread_inventory.rs
+++ b/codex-rs/cli/src/doctor/thread_inventory.rs
@@ -1,0 +1,921 @@
+//! Doctor check that compares rollout files against the SQLite thread inventory.
+
+use super::CheckStatus;
+use super::Config;
+use super::DoctorCheck;
+use super::DoctorIssue;
+use codex_protocol::protocol::InternalSessionSource;
+use codex_protocol::protocol::SessionSource;
+use codex_protocol::protocol::SubAgentSource;
+use codex_rollout::RolloutRecorder;
+use codex_state::ThreadStateAuditRow;
+use codex_utils_path::normalize_for_path_comparison;
+use std::collections::BTreeMap;
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::ffi::OsStr;
+use std::path::Path;
+use std::path::PathBuf;
+
+const MAX_PARITY_SCAN_FILES: usize = 10_000;
+const SAMPLE_LIMIT: usize = 5;
+const SUMMARY_LIMIT: usize = 8;
+const CHECK_ID: &str = "state.rollout_db_parity";
+const CHECK_CATEGORY: &str = "threads";
+
+#[derive(Clone, Debug)]
+struct RolloutAuditFile {
+    path: PathBuf,
+    key: PathBuf,
+    archived: bool,
+    thread_id: String,
+}
+
+#[derive(Default)]
+struct RolloutScan {
+    files: Vec<RolloutAuditFile>,
+    scan_errors: Vec<String>,
+    malformed_names: Vec<PathBuf>,
+    reached_scan_cap: bool,
+}
+
+enum RolloutThreadId {
+    Id(String),
+    MalformedName,
+    Unusable(String),
+}
+
+impl RolloutScan {
+    fn candidate_count(&self) -> usize {
+        self.files.len() + self.malformed_names.len() + self.scan_errors.len()
+    }
+
+    fn reached_candidate_cap(&self) -> bool {
+        self.candidate_count() >= MAX_PARITY_SCAN_FILES
+    }
+
+    fn record_malformed_name(&mut self, path: PathBuf) {
+        if self.reached_candidate_cap() {
+            self.reached_scan_cap = true;
+            return;
+        }
+        self.malformed_names.push(path);
+        self.reached_scan_cap = self.reached_candidate_cap();
+    }
+
+    fn record_scan_error(&mut self, message: String) {
+        if self.reached_candidate_cap() {
+            self.reached_scan_cap = true;
+            return;
+        }
+        self.scan_errors.push(message);
+        self.reached_scan_cap = self.reached_candidate_cap();
+    }
+
+    fn active_count(&self) -> usize {
+        self.files.iter().filter(|file| !file.archived).count()
+    }
+
+    fn archived_count(&self) -> usize {
+        self.files.iter().filter(|file| file.archived).count()
+    }
+}
+
+pub(super) async fn thread_inventory_check(config: &Config) -> DoctorCheck {
+    thread_inventory_check_for_roots(
+        config.codex_home.as_path(),
+        config.sqlite_home.as_path(),
+        config.model_provider_id.as_str(),
+    )
+    .await
+}
+
+async fn thread_inventory_check_for_roots(
+    codex_home: &Path,
+    sqlite_home: &Path,
+    default_provider: &str,
+) -> DoctorCheck {
+    let scan = scan_rollout_files(codex_home).await;
+    let state_db_path = codex_state::state_db_path(sqlite_home);
+
+    let mut details = vec![
+        format!("default model provider: {default_provider}"),
+        format!("rollout DB active files: {}", scan.active_count()),
+        format!("rollout DB archived files: {}", scan.archived_count()),
+        format!("rollout DB scan errors: {}", scan.scan_errors.len()),
+        format!(
+            "rollout DB malformed file names: {}",
+            scan.malformed_names.len()
+        ),
+        format!("rollout DB scan cap reached: {}", scan.reached_scan_cap),
+    ];
+    push_samples(
+        &mut details,
+        "rollout DB scan error sample",
+        scan.scan_errors.iter().map(String::as_str),
+    );
+    push_samples(
+        &mut details,
+        "rollout DB malformed file sample",
+        scan.malformed_names
+            .iter()
+            .map(|path| path.display().to_string()),
+    );
+
+    if !state_db_path.is_file() {
+        details.push("rollout DB rows: skipped (state DB missing)".to_string());
+        return missing_state_db_check(scan, details);
+    }
+
+    let rows = match codex_state::read_thread_state_audit_rows(&state_db_path).await {
+        Ok(rows) => rows,
+        Err(err) => {
+            details.push(format!("rollout DB read error: {err}"));
+            return DoctorCheck::new(
+                CHECK_ID,
+                CHECK_CATEGORY,
+                CheckStatus::Warning,
+                "state database thread inventory could not be read",
+            )
+            .details(details)
+            .issue(
+                DoctorIssue::new(
+                    CheckStatus::Warning,
+                    "state DB thread rows could not be queried",
+                )
+                .measured(err.to_string())
+                .expected("readable threads table"),
+            );
+        }
+    };
+
+    parity_check_from_scan_and_rows(codex_home, scan, rows, details)
+}
+
+fn missing_state_db_check(scan: RolloutScan, details: Vec<String>) -> DoctorCheck {
+    if scan.files.is_empty()
+        && scan.scan_errors.is_empty()
+        && scan.malformed_names.is_empty()
+        && !scan.reached_scan_cap
+    {
+        return DoctorCheck::new(
+            CHECK_ID,
+            CHECK_CATEGORY,
+            CheckStatus::Ok,
+            "no rollout/state DB inventory to compare",
+        )
+        .details(details);
+    }
+
+    let summary = if scan.files.is_empty() {
+        "rollout scan was incomplete or found bad files"
+    } else {
+        "state DB is missing while rollout files exist"
+    };
+    let mut check =
+        DoctorCheck::new(CHECK_ID, CHECK_CATEGORY, CheckStatus::Warning, summary).details(details);
+
+    if !scan.files.is_empty() {
+        check = check
+            .issue(
+                DoctorIssue::new(
+                    CheckStatus::Warning,
+                    "rollout files exist but the state DB is missing",
+                )
+                .measured(format!("{} rollout files", scan.files.len()))
+                .expected("state DB contains matching thread rows")
+                .remedy("Start Codex with no state DB present so startup backfill can create it from rollout files."),
+        )
+            .remediation(
+                "Start Codex with no state DB present so startup backfill can create it from rollout files.",
+            );
+    }
+    if !scan.scan_errors.is_empty() || !scan.malformed_names.is_empty() || scan.reached_scan_cap {
+        check = check.issue(
+            DoctorIssue::new(
+                CheckStatus::Warning,
+                "rollout scan was incomplete or found bad files",
+            )
+            .measured(format!(
+                "{} scan errors, {} malformed names, scan cap reached: {}",
+                scan.scan_errors.len(),
+                scan.malformed_names.len(),
+                scan.reached_scan_cap
+            ))
+            .expected("rollout directories are fully scannable")
+            .remedy("Check file permissions and unexpected files under CODEX_HOME sessions."),
+        );
+    }
+    check
+}
+
+fn parity_check_from_scan_and_rows(
+    codex_home: &Path,
+    scan: RolloutScan,
+    rows: Vec<ThreadStateAuditRow>,
+    mut details: Vec<String>,
+) -> DoctorCheck {
+    let rollout_by_key = scan
+        .files
+        .iter()
+        .map(|file| (file.key.clone(), file))
+        .collect::<HashMap<_, _>>();
+    let mut rows_by_key: HashMap<PathBuf, Vec<&ThreadStateAuditRow>> = HashMap::new();
+    for row in &rows {
+        rows_by_key
+            .entry(path_key(&row.rollout_path))
+            .or_default()
+            .push(row);
+    }
+
+    let missing_active = missing_rollout_paths(&scan.files, &rows_by_key, /*archived*/ false);
+    let missing_archived = missing_rollout_paths(&scan.files, &rows_by_key, /*archived*/ true);
+    let scan_complete = !scan.reached_scan_cap;
+    let stale_rows = if scan_complete {
+        rows.iter()
+            .filter(|row| !row.rollout_path.is_file())
+            .collect::<Vec<_>>()
+    } else {
+        Vec::new()
+    };
+    let archive_mismatches = if scan_complete {
+        rows.iter()
+            .filter_map(|row| {
+                let expected_archived = rollout_by_key
+                    .get(&path_key(&row.rollout_path))
+                    .map(|file| file.archived)
+                    .or_else(|| {
+                        row.rollout_path
+                            .is_file()
+                            .then(|| archived_from_rollout_path(codex_home, &row.rollout_path))
+                            .flatten()
+                    })?;
+                (expected_archived != row.archived).then_some(row)
+            })
+            .collect::<Vec<_>>()
+    } else {
+        Vec::new()
+    };
+    let duplicate_rollout_thread_ids = duplicate_rollout_thread_ids(&scan.files);
+    let duplicate_db_paths = duplicate_db_paths(&rows_by_key);
+    let archived_rows = rows.iter().filter(|row| row.archived).count();
+    let active_rows = rows.len() - archived_rows;
+
+    details.extend([
+        format!("rollout DB rows: {}", rows.len()),
+        format!("rollout DB active rows: {active_rows}"),
+        format!("rollout DB archived rows: {archived_rows}"),
+        format!("rollout DB missing active rows: {}", missing_active.len()),
+        format!(
+            "rollout DB missing archived rows: {}",
+            missing_archived.len()
+        ),
+        format!(
+            "rollout DB stale rows: {}",
+            count_or_skipped(stale_rows.len(), scan_complete)
+        ),
+        format!(
+            "rollout DB archive mismatches: {}",
+            count_or_skipped(archive_mismatches.len(), scan_complete)
+        ),
+        format!(
+            "rollout DB duplicate rollout thread ids: {}",
+            duplicate_rollout_thread_ids.len()
+        ),
+        format!(
+            "rollout DB duplicate DB paths: {}",
+            duplicate_db_paths.len()
+        ),
+        format!(
+            "rollout DB model providers: {}",
+            count_summary(rows.iter().map(|row| row.model_provider.as_str()))
+        ),
+        format!(
+            "rollout DB sources: {}",
+            count_summary(rows.iter().map(|row| source_category(&row.source)))
+        ),
+    ]);
+    push_path_samples(
+        &mut details,
+        "rollout DB missing active sample",
+        missing_active.iter().copied(),
+    );
+    push_path_samples(
+        &mut details,
+        "rollout DB missing archived sample",
+        missing_archived.iter().copied(),
+    );
+    push_path_samples(
+        &mut details,
+        "rollout DB stale row sample",
+        stale_rows.iter().map(|row| row.rollout_path.as_path()),
+    );
+    push_path_samples(
+        &mut details,
+        "rollout DB archive mismatch sample",
+        archive_mismatches
+            .iter()
+            .map(|row| row.rollout_path.as_path()),
+    );
+    push_samples(
+        &mut details,
+        "rollout DB duplicate rollout thread id sample",
+        duplicate_rollout_thread_ids.iter().map(String::as_str),
+    );
+    push_path_samples(
+        &mut details,
+        "rollout DB duplicate DB path sample",
+        duplicate_db_paths.iter().map(PathBuf::as_path),
+    );
+
+    let status = if scan.scan_errors.is_empty()
+        && scan.malformed_names.is_empty()
+        && !scan.reached_scan_cap
+        && missing_active.is_empty()
+        && missing_archived.is_empty()
+        && stale_rows.is_empty()
+        && archive_mismatches.is_empty()
+        && duplicate_rollout_thread_ids.is_empty()
+        && duplicate_db_paths.is_empty()
+    {
+        CheckStatus::Ok
+    } else {
+        CheckStatus::Warning
+    };
+
+    let summary = if status == CheckStatus::Ok {
+        "rollout files and state DB thread inventory agree"
+    } else {
+        "rollout files and state DB thread inventory differ"
+    };
+    let mut check = DoctorCheck::new(CHECK_ID, CHECK_CATEGORY, status, summary).details(details);
+
+    if !missing_active.is_empty() || !missing_archived.is_empty() {
+        check = check.issue(
+            DoctorIssue::new(
+                CheckStatus::Warning,
+                "rollout files are missing from the state DB",
+            )
+            .measured(format!(
+                "{} active, {} archived",
+                missing_active.len(),
+                missing_archived.len()
+            ))
+            .expected("every rollout file has a matching threads row"),
+        );
+    }
+    if !stale_rows.is_empty() {
+        check = check.issue(
+            DoctorIssue::new(
+                CheckStatus::Warning,
+                "state DB rows point at missing or unusable rollout files",
+            )
+            .measured(format!("{} stale rows", stale_rows.len()))
+            .expected("every state DB rollout path is a file on disk"),
+        );
+    }
+    if !archive_mismatches.is_empty() {
+        check = check.issue(
+            DoctorIssue::new(
+                CheckStatus::Warning,
+                "state DB archive flags disagree with rollout file locations",
+            )
+            .measured(format!("{} mismatched rows", archive_mismatches.len()))
+            .expected(
+                "rows under archived_sessions are archived and rows under sessions are active",
+            ),
+        );
+    }
+    if !duplicate_rollout_thread_ids.is_empty() || !duplicate_db_paths.is_empty() {
+        check = check.issue(
+            DoctorIssue::new(
+                CheckStatus::Warning,
+                "duplicate thread inventory entries found",
+            )
+            .measured(format!(
+                "{} duplicate rollout thread ids, {} duplicate DB paths",
+                duplicate_rollout_thread_ids.len(),
+                duplicate_db_paths.len()
+            ))
+            .expected("one rollout path and thread id per thread")
+            .remedy("Attach the doctor report to a bug report so support can inspect samples."),
+        );
+    }
+    if !scan.scan_errors.is_empty() || !scan.malformed_names.is_empty() || scan.reached_scan_cap {
+        check = check.issue(
+            DoctorIssue::new(
+                CheckStatus::Warning,
+                "rollout scan was incomplete or found bad files",
+            )
+            .measured(format!(
+                "{} scan errors, {} malformed names, scan cap reached: {}",
+                scan.scan_errors.len(),
+                scan.malformed_names.len(),
+                scan.reached_scan_cap
+            ))
+            .expected("rollout directories are fully scannable")
+            .remedy("Check file permissions and unexpected files under CODEX_HOME sessions."),
+        );
+    }
+    check
+}
+
+async fn scan_rollout_files(codex_home: &Path) -> RolloutScan {
+    let mut scan = RolloutScan::default();
+    scan_rollout_root(
+        &codex_home.join("sessions"),
+        /*archived*/ false,
+        &mut scan,
+    )
+    .await;
+    scan_rollout_root(
+        &codex_home.join("archived_sessions"),
+        /*archived*/ true,
+        &mut scan,
+    )
+    .await;
+    scan
+}
+
+async fn scan_rollout_root(root: &Path, archived: bool, scan: &mut RolloutScan) {
+    let mut dirs = vec![root.to_path_buf()];
+    while let Some(dir) = dirs.pop() {
+        if scan.reached_scan_cap {
+            return;
+        }
+        let entries = match std::fs::read_dir(&dir) {
+            Ok(entries) => entries,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(err) => {
+                scan.record_scan_error(format!("{} ({err})", dir.display()));
+                continue;
+            }
+        };
+        for entry in entries {
+            if scan.reached_scan_cap {
+                return;
+            }
+            let entry = match entry {
+                Ok(entry) => entry,
+                Err(err) => {
+                    scan.record_scan_error(format!("{} ({err})", dir.display()));
+                    continue;
+                }
+            };
+            let path = entry.path();
+            let file_type = match entry.file_type() {
+                Ok(file_type) => file_type,
+                Err(err) => {
+                    scan.record_scan_error(format!("{} ({err})", path.display()));
+                    continue;
+                }
+            };
+            if file_type.is_dir() {
+                dirs.push(path);
+                continue;
+            }
+            if !file_type.is_file() || !is_rollout_file(&path) {
+                continue;
+            }
+            if scan.candidate_count() >= MAX_PARITY_SCAN_FILES {
+                scan.reached_scan_cap = true;
+                return;
+            }
+            let thread_id = match thread_id_from_rollout(&path).await {
+                RolloutThreadId::Id(thread_id) => thread_id,
+                RolloutThreadId::MalformedName => {
+                    scan.record_malformed_name(path.clone());
+                    continue;
+                }
+                RolloutThreadId::Unusable(reason) => {
+                    scan.record_scan_error(format!("{} ({reason})", path.display()));
+                    continue;
+                }
+            };
+            scan.files.push(RolloutAuditFile {
+                key: path_key(&path),
+                path,
+                archived,
+                thread_id,
+            });
+        }
+    }
+}
+
+async fn thread_id_from_rollout(path: &Path) -> RolloutThreadId {
+    let items = match RolloutRecorder::load_rollout_items(path).await {
+        Ok((items, _, _)) => items,
+        Err(err) => return RolloutThreadId::Unusable(err.to_string()),
+    };
+    if items.is_empty() {
+        return RolloutThreadId::Unusable("no parseable rollout items".to_string());
+    }
+    codex_rollout::builder_from_items(items.as_slice(), path)
+        .map(|builder| RolloutThreadId::Id(builder.id.to_string()))
+        .unwrap_or(RolloutThreadId::MalformedName)
+}
+
+fn is_rollout_file(path: &Path) -> bool {
+    path.extension() == Some(OsStr::new("jsonl"))
+        && path
+            .file_name()
+            .and_then(OsStr::to_str)
+            .is_some_and(|name| name.starts_with("rollout-"))
+}
+
+fn count_or_skipped(count: usize, complete: bool) -> String {
+    if complete {
+        count.to_string()
+    } else {
+        "skipped (scan cap reached)".to_string()
+    }
+}
+
+fn path_key(path: &Path) -> PathBuf {
+    normalize_for_path_comparison(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+fn archived_from_rollout_path(codex_home: &Path, path: &Path) -> Option<bool> {
+    let key = path_key(path);
+    if key.starts_with(path_key(&codex_home.join("archived_sessions"))) {
+        return Some(true);
+    }
+    if key.starts_with(path_key(&codex_home.join("sessions"))) {
+        return Some(false);
+    }
+    None
+}
+
+fn missing_rollout_paths<'a>(
+    files: &'a [RolloutAuditFile],
+    rows_by_key: &HashMap<PathBuf, Vec<&ThreadStateAuditRow>>,
+    archived: bool,
+) -> Vec<&'a Path> {
+    files
+        .iter()
+        .filter(|file| file.archived == archived && !has_matching_thread_row(file, rows_by_key))
+        .map(|file| file.path.as_path())
+        .collect()
+}
+
+fn has_matching_thread_row(
+    file: &RolloutAuditFile,
+    rows_by_key: &HashMap<PathBuf, Vec<&ThreadStateAuditRow>>,
+) -> bool {
+    let Some(rows) = rows_by_key.get(&file.key) else {
+        return false;
+    };
+    rows.iter().any(|row| row.id == file.thread_id.as_str())
+}
+
+fn duplicate_rollout_thread_ids(files: &[RolloutAuditFile]) -> Vec<String> {
+    let mut seen = HashSet::new();
+    let mut duplicates = HashSet::new();
+    for thread_id in files.iter().map(|file| file.thread_id.as_str()) {
+        if !seen.insert(thread_id) {
+            duplicates.insert(thread_id.to_string());
+        }
+    }
+    let mut duplicates = duplicates.into_iter().collect::<Vec<_>>();
+    duplicates.sort();
+    duplicates
+}
+
+fn duplicate_db_paths(rows_by_key: &HashMap<PathBuf, Vec<&ThreadStateAuditRow>>) -> Vec<PathBuf> {
+    let mut paths = rows_by_key
+        .iter()
+        .filter(|(_, rows)| rows.len() > 1)
+        .map(|(path, _)| path.clone())
+        .collect::<Vec<_>>();
+    paths.sort();
+    paths
+}
+
+fn source_category(source: &str) -> &'static str {
+    let parsed = serde_json::from_str::<SessionSource>(source)
+        .or_else(|_| serde_json::from_value(serde_json::Value::String(source.to_string())));
+    let Ok(source) = parsed else {
+        return "unparsable";
+    };
+
+    match source {
+        SessionSource::Cli => "cli",
+        SessionSource::VSCode => "vscode",
+        SessionSource::Exec => "exec",
+        SessionSource::Mcp => "mcp",
+        SessionSource::Custom(_) => "custom",
+        SessionSource::Internal(InternalSessionSource::MemoryConsolidation) => {
+            "internal:memory_consolidation"
+        }
+        SessionSource::SubAgent(SubAgentSource::Review) => "subagent:review",
+        SessionSource::SubAgent(SubAgentSource::Compact) => "subagent:compact",
+        SessionSource::SubAgent(SubAgentSource::ThreadSpawn { .. }) => "subagent:thread_spawn",
+        SessionSource::SubAgent(SubAgentSource::MemoryConsolidation) => {
+            "subagent:memory_consolidation"
+        }
+        SessionSource::SubAgent(SubAgentSource::Other(_)) => "subagent:other",
+        SessionSource::Unknown => "unknown",
+    }
+}
+
+fn count_summary<I, V>(values: I) -> String
+where
+    I: Iterator<Item = V>,
+    V: Into<String>,
+{
+    let mut counts = BTreeMap::<String, usize>::new();
+    for value in values {
+        *counts.entry(value.into()).or_default() += 1;
+    }
+    if counts.is_empty() {
+        return "none".to_string();
+    }
+
+    let mut entries = counts.into_iter().collect::<Vec<_>>();
+    entries.sort_by(|(left_value, left_count), (right_value, right_count)| {
+        right_count
+            .cmp(left_count)
+            .then_with(|| left_value.cmp(right_value))
+    });
+    let omitted_categories = entries.len().saturating_sub(SUMMARY_LIMIT);
+    let omitted_rows = entries
+        .iter()
+        .skip(SUMMARY_LIMIT)
+        .map(|(_, count)| count)
+        .sum::<usize>();
+    let mut parts = entries
+        .into_iter()
+        .take(SUMMARY_LIMIT)
+        .map(|(value, count)| format!("{value}={count}"))
+        .collect::<Vec<_>>();
+    if omitted_categories > 0 {
+        parts.push(format!(
+            "other={omitted_rows} across {omitted_categories} categories"
+        ));
+    }
+    parts.join(", ")
+}
+
+fn push_path_samples<'a>(
+    details: &mut Vec<String>,
+    label: &str,
+    paths: impl Iterator<Item = &'a Path>,
+) {
+    push_samples(details, label, paths.map(|path| path.display().to_string()));
+}
+
+fn push_samples<I, V>(details: &mut Vec<String>, label: &str, values: I)
+where
+    I: Iterator<Item = V>,
+    V: ToString,
+{
+    for value in values.take(SAMPLE_LIMIT) {
+        details.push(format!("{label}: {}", value.to_string()));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use codex_protocol::ThreadId;
+    use codex_protocol::protocol::RolloutItem;
+    use codex_protocol::protocol::RolloutLine;
+    use pretty_assertions::assert_eq;
+    use sqlx::sqlite::SqliteConnectOptions;
+    use sqlx::sqlite::SqlitePoolOptions;
+    use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn thread_inventory_check_ok_when_rollouts_match_db() {
+        let fixture = Fixture::new().await;
+        let active_path = fixture.write_rollout(
+            /*archived*/ false,
+            "2025-01-02T10-00-00",
+            "00000000-0000-0000-0000-000000000001",
+        );
+        let archived_path = fixture.write_rollout(
+            /*archived*/ true,
+            "2025-01-02T11-00-00",
+            "00000000-0000-0000-0000-000000000002",
+        );
+        fixture
+            .insert_thread_row(
+                "00000000-0000-0000-0000-000000000001",
+                active_path.as_path(),
+                /*archived*/ false,
+            )
+            .await;
+        fixture
+            .insert_thread_row(
+                "00000000-0000-0000-0000-000000000002",
+                archived_path.as_path(),
+                /*archived*/ true,
+            )
+            .await;
+
+        let check = thread_inventory_check_for_roots(
+            fixture.codex_home.path(),
+            fixture.sqlite_home.path(),
+            "test-provider",
+        )
+        .await;
+
+        assert_eq!(check.status, CheckStatus::Ok);
+        assert_eq!(check.category, CHECK_CATEGORY);
+        assert_detail(&check, "rollout DB missing active rows", "0");
+        assert_detail(&check, "rollout DB missing archived rows", "0");
+        assert_detail(&check, "rollout DB stale rows", "0");
+        assert_detail(&check, "rollout DB archive mismatches", "0");
+    }
+
+    #[tokio::test]
+    async fn thread_inventory_check_warns_for_missing_stale_and_mismatched_rows() {
+        let fixture = Fixture::new().await;
+        let missing_path = fixture.write_rollout(
+            /*archived*/ false,
+            "2025-01-02T10-00-00",
+            "00000000-0000-0000-0000-000000000001",
+        );
+        let mismatched_path = fixture.write_rollout(
+            /*archived*/ true,
+            "2025-01-02T11-00-00",
+            "00000000-0000-0000-0000-000000000002",
+        );
+        let stale_path = fixture
+            .codex_home
+            .path()
+            .join("sessions/2025/01/02/rollout-2025-01-02T12-00-00-00000000-0000-0000-0000-000000000003.jsonl");
+        fixture
+            .insert_thread_row(
+                "00000000-0000-0000-0000-000000000002",
+                mismatched_path.as_path(),
+                /*archived*/ false,
+            )
+            .await;
+        fixture
+            .insert_thread_row(
+                "00000000-0000-0000-0000-000000000003",
+                stale_path.as_path(),
+                /*archived*/ false,
+            )
+            .await;
+
+        let check = thread_inventory_check_for_roots(
+            fixture.codex_home.path(),
+            fixture.sqlite_home.path(),
+            "test-provider",
+        )
+        .await;
+
+        assert_eq!(check.status, CheckStatus::Warning);
+        assert_eq!(check.issues.len(), 3);
+        assert_detail(&check, "rollout DB missing active rows", "1");
+        assert_detail(&check, "rollout DB stale rows", "1");
+        assert_detail(&check, "rollout DB archive mismatches", "1");
+        assert_eq!(check.remediation, None);
+        assert!(check.issues.iter().all(|issue| {
+            !issue
+                .remedy
+                .as_deref()
+                .is_some_and(|remedy| remedy.starts_with("Restart Codex"))
+        }));
+        assert!(
+            check
+                .details
+                .iter()
+                .any(|detail| detail.contains(missing_path.to_string_lossy().as_ref()))
+        );
+    }
+
+    struct Fixture {
+        codex_home: TempDir,
+        sqlite_home: TempDir,
+    }
+
+    impl Fixture {
+        async fn new() -> Self {
+            let codex_home = TempDir::new().expect("codex home");
+            let sqlite_home = TempDir::new().expect("sqlite home");
+            let _runtime = codex_state::StateRuntime::init(
+                sqlite_home.path().to_path_buf(),
+                "test-provider".to_string(),
+            )
+            .await
+            .expect("state runtime");
+            Self {
+                codex_home,
+                sqlite_home,
+            }
+        }
+
+        fn write_rollout(&self, archived: bool, timestamp: &str, thread_id: &str) -> PathBuf {
+            let root = if archived {
+                self.codex_home.path().join("archived_sessions")
+            } else {
+                self.codex_home.path().join("sessions/2025/01/02")
+            };
+            std::fs::create_dir_all(&root).expect("rollout dir");
+            let path = root.join(format!("rollout-{timestamp}-{thread_id}.jsonl"));
+            let rollout_line = RolloutLine {
+                timestamp: timestamp.to_string(),
+                item: RolloutItem::SessionMeta(codex_protocol::protocol::SessionMetaLine {
+                    meta: codex_protocol::protocol::SessionMeta {
+                        id: ThreadId::from_string(thread_id).expect("thread id"),
+                        timestamp: timestamp.to_string(),
+                        cwd: self.codex_home.path().to_path_buf(),
+                        originator: "test".to_string(),
+                        cli_version: "test".to_string(),
+                        source: SessionSource::Cli,
+                        model_provider: Some("test-provider".to_string()),
+                        ..Default::default()
+                    },
+                    git: None,
+                }),
+            };
+            let contents = serde_json::to_string(&rollout_line).expect("rollout line");
+            std::fs::write(&path, format!("{contents}\n")).expect("rollout file");
+            path
+        }
+
+        async fn insert_thread_row(&self, id: &str, rollout_path: &Path, archived: bool) {
+            let state_db_path = codex_state::state_db_path(self.sqlite_home.path());
+            let options = SqliteConnectOptions::new()
+                .filename(state_db_path)
+                .create_if_missing(false);
+            let pool = SqlitePoolOptions::new()
+                .max_connections(1)
+                .connect_with(options)
+                .await
+                .expect("sqlite pool");
+            sqlx::query(
+                r#"
+INSERT INTO threads (
+    id,
+    rollout_path,
+    created_at,
+    updated_at,
+    source,
+    model_provider,
+    cwd,
+    title,
+    sandbox_policy,
+    approval_mode,
+    archived,
+    archived_at
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                "#,
+            )
+            .bind(id)
+            .bind(rollout_path.display().to_string())
+            .bind(1_i64)
+            .bind(1_i64)
+            .bind("cli")
+            .bind("test-provider")
+            .bind(self.codex_home.path().display().to_string())
+            .bind("test title")
+            .bind("read-only")
+            .bind("on-request")
+            .bind(if archived { 1_i64 } else { 0_i64 })
+            .bind(archived.then_some(1_i64))
+            .execute(&pool)
+            .await
+            .expect("insert thread row");
+            pool.close().await;
+        }
+    }
+
+    fn assert_detail(check: &DoctorCheck, label: &str, expected: &str) {
+        let prefix = format!("{label}: ");
+        let actual = check
+            .details
+            .iter()
+            .find_map(|detail| detail.strip_prefix(&prefix))
+            .expect("detail should exist");
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn source_category_coarsens_structured_sources() {
+        assert_eq!(source_category("cli"), "cli");
+        assert_eq!(
+            source_category(r#"{"subagent":"memory_consolidation"}"#),
+            "subagent:memory_consolidation"
+        );
+        assert_eq!(
+            source_category(
+                r#"{"subagent":{"thread_spawn":{"parent_thread_id":"00000000-0000-0000-0000-000000000001","depth":2}}}"#,
+            ),
+            "subagent:thread_spawn"
+        );
+    }
+
+    #[test]
+    fn count_summary_caps_distinct_values() {
+        let summary = count_summary(["a", "b", "c", "d", "e", "f", "g", "h", "i"].into_iter());
+
+        assert_eq!(
+            summary,
+            "a=1, b=1, c=1, d=1, e=1, f=1, g=1, h=1, other=1 across 1 categories"
+        );
+    }
+}

--- a/codex-rs/process-hardening/README.md
+++ b/codex-rs/process-hardening/README.md
@@ -4,5 +4,4 @@ This crate provides `pre_main_hardening()`, which is designed to be called pre-`
 
 - disabling core dumps
 - disabling ptrace attach on Linux and macOS
-- removing dangerous or noisy environment variables such as `LD_PRELOAD`,
-  `DYLD_*`, and macOS malloc stack-logging controls
+- removing dangerous environment variables such as `LD_PRELOAD` and `DYLD_*`

--- a/codex-rs/process-hardening/src/lib.rs
+++ b/codex-rs/process-hardening/src/lib.rs
@@ -8,8 +8,7 @@ use std::os::unix::ffi::OsStrExt;
 /// various process hardening steps, such as
 /// - disabling core dumps
 /// - disabling ptrace attach on Linux and macOS.
-/// - removing dangerous or noisy environment variables such as LD_PRELOAD,
-///   DYLD_*, and macOS malloc stack-logging controls
+/// - removing dangerous environment variables such as LD_PRELOAD and DYLD_*
 pub fn pre_main_hardening() {
     #[cfg(any(target_os = "linux", target_os = "android"))]
     pre_main_hardening_linux();
@@ -98,12 +97,6 @@ pub(crate) fn pre_main_hardening_macos() {
     // Remove all DYLD_ environment variables, which can be used to subvert
     // library loading.
     remove_env_vars_with_prefix(b"DYLD_");
-
-    // Remove macOS malloc stack-logging controls so allocator diagnostics from
-    // Codex or inherited child processes do not get sprayed into the TUI:
-    // https://github.com/openai/codex/issues/11555
-    remove_env_vars_with_prefix(b"MallocStackLogging");
-    remove_env_vars_with_prefix(b"MallocLogFile");
 }
 
 #[cfg(unix)]

--- a/codex-rs/state/src/audit.rs
+++ b/codex-rs/state/src/audit.rs
@@ -1,0 +1,55 @@
+//! Read-only state database queries for diagnostics.
+
+use anyhow::Result;
+use log::LevelFilter;
+use sqlx::ConnectOptions;
+use sqlx::Row;
+use sqlx::sqlite::SqliteConnectOptions;
+use sqlx::sqlite::SqlitePoolOptions;
+use std::path::Path;
+use std::path::PathBuf;
+
+/// Minimal thread metadata used by read-only state database audits.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ThreadStateAuditRow {
+    pub id: String,
+    pub rollout_path: PathBuf,
+    pub archived: bool,
+    pub source: String,
+    pub model_provider: String,
+}
+
+/// Read persisted thread rows from a state DB without creating, migrating, or repairing it.
+pub async fn read_thread_state_audit_rows(path: &Path) -> Result<Vec<ThreadStateAuditRow>> {
+    let options = SqliteConnectOptions::new()
+        .filename(path)
+        .create_if_missing(false)
+        .read_only(true)
+        .log_statements(LevelFilter::Off);
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect_with(options)
+        .await?;
+    let rows = sqlx::query(
+        r#"
+SELECT id, rollout_path, archived, source, model_provider
+FROM threads
+        "#,
+    )
+    .fetch_all(&pool)
+    .await?;
+    pool.close().await;
+
+    rows.into_iter()
+        .map(|row| {
+            let archived: i64 = row.try_get("archived")?;
+            Ok(ThreadStateAuditRow {
+                id: row.try_get("id")?,
+                rollout_path: PathBuf::from(row.try_get::<String, _>("rollout_path")?),
+                archived: archived != 0,
+                source: row.try_get("source")?,
+                model_provider: row.try_get("model_provider")?,
+            })
+        })
+        .collect()
+}

--- a/codex-rs/state/src/lib.rs
+++ b/codex-rs/state/src/lib.rs
@@ -4,6 +4,7 @@
 //! from JSONL rollouts and mirrors it into a local SQLite database. Backfill
 //! orchestration and rollout scanning live in `codex-core`.
 
+mod audit;
 mod extract;
 pub mod log_db;
 mod migrations;
@@ -19,6 +20,8 @@ pub use model::Phase2JobClaimOutcome;
 /// Preferred entrypoint: owns configuration and metrics.
 pub use runtime::StateRuntime;
 
+pub use audit::ThreadStateAuditRow;
+pub use audit::read_thread_state_audit_rows;
 /// Low-level storage engine: useful for focused tests.
 ///
 /// Most consumers should prefer [`StateRuntime`].

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -754,6 +754,10 @@ impl App {
         let bootstrap_ms = bootstrap_started_at.elapsed().as_millis();
         let mut model = bootstrap.default_model;
         let available_models = bootstrap.available_models;
+        let remote_connection = crate::status::remote_connection::remote_connection_status_value(
+            &app_server_target,
+            app_server.server_version(),
+        );
         let exit_info = handle_model_migration_prompt_if_needed(
             tui,
             &mut config,
@@ -942,6 +946,7 @@ impl App {
                 (ChatWidget::new_with_app_event(init), Some(forked))
             }
         };
+        chat_widget.remote_connection = remote_connection;
         let thread_and_widget_ms = thread_and_widget_started_at.elapsed().as_millis();
         if let Some(message) = external_agent_config_migration_message {
             chat_widget.add_info_message(message, /*hint*/ None);

--- a/codex-rs/tui/src/app/background_requests.rs
+++ b/codex-rs/tui/src/app/background_requests.rs
@@ -529,14 +529,13 @@ impl App {
     /// Process the completed MCP inventory fetch: clear the loading spinner, then
     /// render either the full tool/resource listing or an error into chat history.
     ///
-    /// When both the local config and the app-server report zero servers, a special
-    /// "empty" cell is shown instead of the full table.
+    /// When the app-server reports zero servers, a special "empty" cell is shown
+    /// instead of the full table.
     pub(super) fn handle_mcp_inventory_result(
         &mut self,
         result: Result<Vec<McpServerStatus>, String>,
         detail: McpServerStatusDetail,
     ) {
-        let config = self.chat_widget.config_ref().clone();
         self.chat_widget.clear_mcp_inventory_loading();
         self.clear_committed_mcp_inventory_loading();
 
@@ -549,7 +548,7 @@ impl App {
             }
         };
 
-        if config.mcp_servers.get().is_empty() && statuses.is_empty() {
+        if statuses.is_empty() {
             self.chat_widget
                 .add_to_history(history_cell::empty_mcp_output());
             return;
@@ -557,7 +556,7 @@ impl App {
 
         self.chat_widget
             .add_to_history(history_cell::new_mcp_tools_output_from_statuses(
-                &config, &statuses, detail,
+                &statuses, detail,
             ));
     }
 

--- a/codex-rs/tui/src/app/session_lifecycle.rs
+++ b/codex-rs/tui/src/app/session_lifecycle.rs
@@ -268,6 +268,7 @@ impl App {
         if chat_widget.last_terminal_title.is_none() {
             chat_widget.last_terminal_title = previous_terminal_title;
         }
+        chat_widget.remote_connection = self.chat_widget.remote_connection.clone();
         for (thread_id, entry) in self.agent_navigation.ordered_threads() {
             chat_widget.set_collab_agent_metadata(
                 thread_id,

--- a/codex-rs/tui/src/app_server_session.rs
+++ b/codex-rs/tui/src/app_server_session.rs
@@ -1259,6 +1259,9 @@ fn config_request_overrides_from_config(
         "web_search",
         Some(config.web_search_mode.value().to_string()),
     );
+    if config.bypass_hook_trust {
+        overrides.insert("bypass_hook_trust".to_string(), true.into());
+    }
     Some(overrides)
 }
 
@@ -2131,7 +2134,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn thread_lifecycle_params_forward_model_reasoning_and_service_tier() {
+    async fn thread_lifecycle_params_forward_config_overrides_and_service_tier() {
         let temp_dir = tempfile::tempdir().expect("tempdir");
         let mut config = build_config(&temp_dir).await;
         config.model_reasoning_effort = Some(ReasoningEffort::High);
@@ -2142,6 +2145,7 @@ mod tests {
             .web_search_mode
             .set(WebSearchMode::Disabled)
             .expect("test web search mode should be allowed");
+        config.bypass_hook_trust = true;
         config.service_tier = Some(ServiceTier::Fast.request_value().to_string());
         let thread_id = ThreadId::new();
 
@@ -2175,6 +2179,7 @@ mod tests {
             ("model_verbosity".to_string(), string("low")),
             ("personality".to_string(), string("pragmatic")),
             ("web_search".to_string(), string("disabled")),
+            ("bypass_hook_trust".to_string(), true.into()),
         ]);
         assert_eq!(start.config, Some(expected_config.clone()));
         assert_eq!(resume.config, Some(expected_config.clone()));

--- a/codex-rs/tui/src/app_server_session.rs
+++ b/codex-rs/tui/src/app_server_session.rs
@@ -227,6 +227,13 @@ impl AppServerSession {
         matches!(self.thread_params_mode, ThreadParamsMode::Remote)
     }
 
+    pub(crate) fn server_version(&self) -> Option<&str> {
+        let AppServerClient::Remote(client) = &self.client else {
+            return None;
+        };
+        client.server_version()
+    }
+
     pub(crate) async fn bootstrap(&mut self, config: &Config) -> Result<AppServerBootstrap> {
         let account = self.read_account().await?;
         let model_request_id = self.next_request_id();

--- a/codex-rs/tui/src/bottom_pane/status_line_setup.rs
+++ b/codex-rs/tui/src/bottom_pane/status_line_setup.rs
@@ -638,7 +638,7 @@ mod tests {
                 ),
                 (
                     StatusLineItem::WeeklyLimit.preview_item(),
-                    "weekly 82%".to_string(),
+                    "weekly 82% left".to_string(),
                 ),
             ]),
             AppEventSender::new(tx_raw),

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -315,6 +315,7 @@ use crate::render::renderable::RenderableExt;
 use crate::render::renderable::RenderableItem;
 use crate::slash_command::SlashCommand;
 use crate::status::RateLimitSnapshotDisplay;
+use crate::status::remote_connection::RemoteConnectionStatus;
 use crate::status_indicator_widget::STATUS_DETAILS_DEFAULT_MAX_LINES;
 use crate::status_indicator_widget::StatusDetailsCapitalization;
 use crate::text_formatting::truncate_text;
@@ -535,6 +536,7 @@ pub(crate) struct ChatWidget {
     initial_user_message: Option<UserMessage>,
     status_account_display: Option<StatusAccountDisplay>,
     runtime_model_provider_base_url: Option<String>,
+    pub(crate) remote_connection: Option<RemoteConnectionStatus>,
     token_info: Option<TokenUsageInfo>,
     rate_limit_snapshots_by_limit_id: BTreeMap<String, RateLimitSnapshotDisplay>,
     refreshing_status_outputs: Vec<(u64, StatusHistoryHandle)>,

--- a/codex-rs/tui/src/chatwidget/constructor.rs
+++ b/codex-rs/tui/src/chatwidget/constructor.rs
@@ -119,6 +119,7 @@ impl ChatWidget {
             initial_user_message,
             status_account_display,
             runtime_model_provider_base_url,
+            remote_connection: None,
             token_info: None,
             rate_limit_snapshots_by_limit_id: BTreeMap::new(),
             refreshing_status_outputs: Vec::new(),

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__status_line_setup_popup_rate_limits.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__status_line_setup_popup_rate_limits.snap
@@ -16,5 +16,5 @@ expression: status_line_popup_snapshot(&mut chat)
   [ ] current-dir           Current working directory
   [ ] project-name          Project name (omitted when unavailable)
 
-  monthly 65% · weekly 50%
+  monthly 65% left · weekly 50% left
   Press space to toggle; ←/→ to move; enter to confirm and close; esc to close

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__status_surface_previews_rate_limits.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__status_surface_previews_rate_limits.snap
@@ -2,5 +2,5 @@
 source: tui/src/chatwidget/tests/status_surface_previews.rs
 expression: snapshot
 ---
-status line: monthly 65% · weekly 50%
-terminal title: monthly 65% | weekly 50%
+status line: monthly 65% left · weekly 50% left
+terminal title: monthly 65% left | weekly 50% left

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__terminal_title_setup_popup_rate_limits.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__terminal_title_setup_popup_rate_limits.snap
@@ -16,5 +16,5 @@ expression: terminal_title_popup_snapshot(&mut chat)
   [ ] run-state      Compact session run-state text (Ready, Working, Thinking)
   [ ] thread-title   Current thread title, or thread identifier when unnamed
 
-  monthly 65% | weekly 50%
+  monthly 65% left | weekly 50% left
   Press space to toggle; ←/→ to move; enter to confirm and close; esc to close

--- a/codex-rs/tui/src/chatwidget/status_controls.rs
+++ b/codex-rs/tui/src/chatwidget/status_controls.rs
@@ -377,7 +377,7 @@ impl ChatWidget {
     ) -> Option<String> {
         let window = window?;
         let remaining = (100.0f64 - window.used_percent).clamp(0.0f64, 100.0f64);
-        Some(format!("{label} {remaining:.0}%"))
+        Some(format!("{label} {remaining:.0}% left"))
     }
 
     pub(super) fn status_line_reasoning_effort_label(

--- a/codex-rs/tui/src/chatwidget/status_controls.rs
+++ b/codex-rs/tui/src/chatwidget/status_controls.rs
@@ -225,6 +225,7 @@ impl ChatWidget {
         let (cell, handle) = crate::status::new_status_output_with_rate_limits_handle(
             &self.config,
             self.runtime_model_provider_base_url.as_deref(),
+            self.remote_connection.as_ref(),
             self.status_account_display.as_ref(),
             token_info,
             total_usage,

--- a/codex-rs/tui/src/chatwidget/tests/status_and_layout.rs
+++ b/codex-rs/tui/src/chatwidget/tests/status_and_layout.rs
@@ -586,7 +586,7 @@ async fn status_line_uses_secondary_fallback_for_unsupported_window() {
 
     assert_eq!(
         chat.status_line_value_for_item(crate::bottom_pane::StatusLineItem::WeeklyLimit),
-        Some("secondary usage 50%".to_string())
+        Some("secondary usage 50% left".to_string())
     );
 }
 
@@ -614,11 +614,11 @@ async fn status_line_legacy_limit_items_prefer_matching_windows() {
 
     assert_eq!(
         chat.status_line_value_for_item(crate::bottom_pane::StatusLineItem::FiveHourLimit),
-        Some("5h 60%".to_string())
+        Some("5h 60% left".to_string())
     );
     assert_eq!(
         chat.status_line_value_for_item(crate::bottom_pane::StatusLineItem::WeeklyLimit),
-        Some("weekly 6%".to_string())
+        Some("weekly 6% left".to_string())
     );
 }
 
@@ -646,11 +646,11 @@ async fn status_line_shows_secondary_non_weekly_when_primary_is_weekly() {
 
     assert_eq!(
         chat.status_line_value_for_item(crate::bottom_pane::StatusLineItem::FiveHourLimit),
-        Some("monthly 65%".to_string())
+        Some("monthly 65% left".to_string())
     );
     assert_eq!(
         chat.status_line_value_for_item(crate::bottom_pane::StatusLineItem::WeeklyLimit),
-        Some("weekly 6%".to_string())
+        Some("weekly 6% left".to_string())
     );
 }
 
@@ -678,7 +678,7 @@ async fn status_line_five_hour_item_omits_weekly_only_limit() {
     );
     assert_eq!(
         chat.status_line_value_for_item(crate::bottom_pane::StatusLineItem::WeeklyLimit),
-        Some("weekly 91%".to_string())
+        Some("weekly 91% left".to_string())
     );
 }
 
@@ -702,7 +702,7 @@ async fn status_line_single_monthly_primary_omits_weekly_limit_item() {
 
     assert_eq!(
         chat.status_line_value_for_item(crate::bottom_pane::StatusLineItem::FiveHourLimit),
-        Some("monthly 65%".to_string())
+        Some("monthly 65% left".to_string())
     );
     assert_eq!(
         chat.status_line_value_for_item(crate::bottom_pane::StatusLineItem::WeeklyLimit),
@@ -734,7 +734,7 @@ async fn status_line_secondary_only_non_weekly_limit_omits_primary_limit_item() 
     );
     assert_eq!(
         chat.status_line_value_for_item(crate::bottom_pane::StatusLineItem::WeeklyLimit),
-        Some("monthly 65%".to_string())
+        Some("monthly 65% left".to_string())
     );
 }
 

--- a/codex-rs/tui/src/chatwidget/tests/status_surface_previews.rs
+++ b/codex-rs/tui/src/chatwidget/tests/status_surface_previews.rs
@@ -246,7 +246,7 @@ async fn status_surface_preview_omits_unavailable_rate_limit_items() {
             &mut chat,
             &[StatusLineItem::FiveHourLimit, StatusLineItem::WeeklyLimit]
         ),
-        "weekly 91%"
+        "weekly 91% left"
     );
     assert_eq!(
         title_preview_line(
@@ -256,7 +256,7 @@ async fn status_surface_preview_omits_unavailable_rate_limit_items() {
                 TerminalTitleItem::WeeklyLimit
             ],
         ),
-        "weekly 91%"
+        "weekly 91% left"
     );
 }
 

--- a/codex-rs/tui/src/config_update.rs
+++ b/codex-rs/tui/src/config_update.rs
@@ -122,6 +122,10 @@ pub(crate) fn build_memory_settings_edits(
     ]
 }
 
+pub(crate) fn build_oss_provider_edit(provider: &str) -> ConfigEdit {
+    replace_config_value("oss_provider", serde_json::json!(provider))
+}
+
 pub(crate) async fn write_config_batch(
     request_handle: AppServerRequestHandle,
     edits: Vec<ConfigEdit>,

--- a/codex-rs/tui/src/config_update.rs
+++ b/codex-rs/tui/src/config_update.rs
@@ -15,12 +15,15 @@ use codex_app_server_protocol::MergeStrategy;
 use codex_app_server_protocol::RequestId;
 use codex_app_server_protocol::SkillsConfigWriteParams;
 use codex_app_server_protocol::SkillsConfigWriteResponse;
+use codex_config::loader::project_trust_key;
 use codex_features::FEATURES;
 use codex_protocol::config_types::SERVICE_TIER_DEFAULT_REQUEST_VALUE;
+use codex_protocol::config_types::TrustLevel;
 use codex_utils_absolute_path::AbsolutePathBuf;
 use color_eyre::eyre::Result;
 use color_eyre::eyre::WrapErr;
 use serde_json::Value as JsonValue;
+use std::path::Path;
 use uuid::Uuid;
 
 pub(crate) fn replace_config_value(key_path: impl Into<String>, value: JsonValue) -> ConfigEdit {
@@ -38,6 +41,16 @@ pub(crate) fn clear_config_value(key_path: impl Into<String>) -> ConfigEdit {
 pub(crate) fn app_scoped_key_path(app_id: &str, key_path: &str) -> String {
     let app_id = serde_json::Value::String(app_id.to_string()).to_string();
     format!("apps.{app_id}.{key_path}")
+}
+
+fn trusted_project_edit(project_path: &Path) -> ConfigEdit {
+    let project_key = project_trust_key(project_path)
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"");
+    replace_config_value(
+        format!("projects.\"{project_key}\".trust_level"),
+        serde_json::json!(TrustLevel::Trusted.to_string()),
+    )
 }
 
 pub(crate) fn build_model_selection_edits(
@@ -145,6 +158,13 @@ pub(crate) async fn write_config_batch(
         .wrap_err("config/batchWrite failed in TUI")
 }
 
+pub(crate) async fn write_trusted_project(
+    request_handle: AppServerRequestHandle,
+    project_path: &Path,
+) -> Result<ConfigWriteResponse> {
+    write_config_batch(request_handle, vec![trusted_project_edit(project_path)]).await
+}
+
 pub(crate) async fn read_effective_config(
     request_handle: AppServerRequestHandle,
     cwd: String,
@@ -192,6 +212,18 @@ mod tests {
         assert_eq!(
             app_scoped_key_path("plugin.linear", "enabled"),
             "apps.\"plugin.linear\".enabled"
+        );
+    }
+
+    #[test]
+    fn trusted_project_edit_targets_project_trust_level() {
+        assert_eq!(
+            trusted_project_edit(Path::new("/workspace/team.project")),
+            ConfigEdit {
+                key_path: "projects.\"/workspace/team.project\".trust_level".to_string(),
+                value: serde_json::json!("trusted"),
+                merge_strategy: MergeStrategy::Replace,
+            }
         );
     }
 }

--- a/codex-rs/tui/src/history_cell/mcp.rs
+++ b/codex-rs/tui/src/history_cell/mcp.rs
@@ -512,14 +512,13 @@ pub(crate) fn new_mcp_tools_output(
 /// Build the `/mcp` history cell from app-server `McpServerStatus` responses.
 ///
 /// The server list comes directly from the app-server status response, sorted
-/// alphabetically. Local config is only used to enrich returned servers with
-/// transport details such as command, URL, cwd, and environment display.
+/// alphabetically. The TUI deliberately does not enrich these rows from
+/// client-local config because the app-server owns the remote MCP state.
 ///
 /// This mirrors the layout of [`new_mcp_tools_output`] but sources data from
 /// the paginated RPC response rather than the in-process `McpManager`. The
 /// `detail` flag controls whether resources and resource templates are rendered.
 pub(crate) fn new_mcp_tools_output_from_statuses(
-    config: &Config,
     statuses: &[McpServerStatus],
     detail: McpServerStatusDetail,
 ) -> PlainHistoryCell {
@@ -530,13 +529,8 @@ pub(crate) fn new_mcp_tools_output_from_statuses(
         "".into(),
     ];
 
-    let mut statuses_by_name = HashMap::new();
-    for status in statuses {
-        statuses_by_name.insert(status.name.as_str(), status);
-    }
-
-    let mut server_names: Vec<String> = statuses.iter().map(|status| status.name.clone()).collect();
-    server_names.sort();
+    let mut statuses = statuses.iter().collect::<Vec<_>>();
+    statuses.sort_by(|a, b| a.name.cmp(&b.name));
 
     let has_any_tools = statuses.iter().any(|status| !status.tools.is_empty());
     if !has_any_tools {
@@ -544,32 +538,16 @@ pub(crate) fn new_mcp_tools_output_from_statuses(
         lines.push("".into());
     }
 
-    for server in server_names {
-        let cfg = config.mcp_servers.get().get(server.as_str());
-        let status = statuses_by_name.get(server.as_str()).copied();
-        let header: Vec<Span<'static>> = vec!["  • ".into(), server.clone().into()];
+    for status in statuses {
+        let header: Vec<Span<'static>> = vec!["  • ".into(), status.name.clone().into()];
 
         lines.push(header.into());
-        if matches!(detail, McpServerStatusDetail::Full) {
-            let enabled = cfg.map(|cfg| cfg.enabled).unwrap_or(true);
-            let status_text = if enabled {
-                "enabled".green()
-            } else {
-                "disabled".red()
-            };
-            lines.push(vec!["    • Status: ".into(), status_text].into());
-            if let Some(reason) = cfg.and_then(|cfg| cfg.disabled_reason.as_ref()) {
-                lines.push(vec!["    • Reason: ".into(), reason.to_string().dim()].into());
-            }
-        }
-        let auth_status = status
-            .map(|status| match status.auth_status {
-                codex_app_server_protocol::McpAuthStatus::Unsupported => McpAuthStatus::Unsupported,
-                codex_app_server_protocol::McpAuthStatus::NotLoggedIn => McpAuthStatus::NotLoggedIn,
-                codex_app_server_protocol::McpAuthStatus::BearerToken => McpAuthStatus::BearerToken,
-                codex_app_server_protocol::McpAuthStatus::OAuth => McpAuthStatus::OAuth,
-            })
-            .unwrap_or(McpAuthStatus::Unsupported);
+        let auth_status = match status.auth_status {
+            codex_app_server_protocol::McpAuthStatus::Unsupported => McpAuthStatus::Unsupported,
+            codex_app_server_protocol::McpAuthStatus::NotLoggedIn => McpAuthStatus::NotLoggedIn,
+            codex_app_server_protocol::McpAuthStatus::BearerToken => McpAuthStatus::BearerToken,
+            codex_app_server_protocol::McpAuthStatus::OAuth => McpAuthStatus::OAuth,
+        };
         lines.push(
             vec![
                 "    • Auth: ".into(),
@@ -578,72 +556,7 @@ pub(crate) fn new_mcp_tools_output_from_statuses(
             .into(),
         );
 
-        if let Some(cfg) = cfg {
-            match &cfg.transport {
-                McpServerTransportConfig::Stdio {
-                    command,
-                    args,
-                    env,
-                    env_vars,
-                    cwd,
-                } => {
-                    let args_suffix = if args.is_empty() {
-                        String::new()
-                    } else {
-                        format!(" {}", args.join(" "))
-                    };
-                    let cmd_display = format!("{command}{args_suffix}");
-                    lines.push(vec!["    • Command: ".into(), cmd_display.into()].into());
-
-                    if let Some(cwd) = cwd.as_ref() {
-                        lines.push(
-                            vec!["    • Cwd: ".into(), cwd.display().to_string().into()].into(),
-                        );
-                    }
-
-                    let env_display = format_env_display(env.as_ref(), env_vars.as_slice());
-                    if env_display != "-" {
-                        lines.push(vec!["    • Env: ".into(), env_display.into()].into());
-                    }
-                }
-                McpServerTransportConfig::StreamableHttp {
-                    url,
-                    http_headers,
-                    env_http_headers,
-                    ..
-                } => {
-                    lines.push(vec!["    • URL: ".into(), url.clone().into()].into());
-                    if let Some(headers) = http_headers.as_ref()
-                        && !headers.is_empty()
-                    {
-                        let mut pairs: Vec<_> = headers.iter().collect();
-                        pairs.sort_by(|(a, _), (b, _)| a.cmp(b));
-                        let display = pairs
-                            .into_iter()
-                            .map(|(name, _)| format!("{name}=*****"))
-                            .collect::<Vec<_>>()
-                            .join(", ");
-                        lines.push(vec!["    • HTTP headers: ".into(), display.into()].into());
-                    }
-                    if let Some(headers) = env_http_headers.as_ref()
-                        && !headers.is_empty()
-                    {
-                        let mut pairs: Vec<_> = headers.iter().collect();
-                        pairs.sort_by(|(a, _), (b, _)| a.cmp(b));
-                        let display = pairs
-                            .into_iter()
-                            .map(|(name, var)| format!("{name}={var}"))
-                            .collect::<Vec<_>>()
-                            .join(", ");
-                        lines.push(vec!["    • Env HTTP headers: ".into(), display.into()].into());
-                    }
-                }
-            }
-        }
-
-        let mut names = status
-            .map(|status| status.tools.keys().cloned().collect::<Vec<_>>())
-            .unwrap_or_default();
+        let mut names = status.tools.keys().cloned().collect::<Vec<_>>();
         names.sort();
         if names.is_empty() {
             lines.push("    • Tools: (none)".into());
@@ -652,9 +565,7 @@ pub(crate) fn new_mcp_tools_output_from_statuses(
         }
 
         if matches!(detail, McpServerStatusDetail::Full) {
-            let server_resources = status
-                .map(|status| status.resources.clone())
-                .unwrap_or_default();
+            let server_resources = status.resources.clone();
             if server_resources.is_empty() {
                 lines.push("    • Resources: (none)".into());
             } else {
@@ -674,9 +585,7 @@ pub(crate) fn new_mcp_tools_output_from_statuses(
                 lines.push(spans.into());
             }
 
-            let server_templates = status
-                .map(|status| status.resource_templates.clone())
-                .unwrap_or_default();
+            let server_templates = status.resource_templates.clone();
             if server_templates.is_empty() {
                 lines.push("    • Resource templates: (none)".into());
             } else {

--- a/codex-rs/tui/src/history_cell/messages.rs
+++ b/codex-rs/tui/src/history_cell/messages.rs
@@ -283,16 +283,26 @@ impl AgentMessageCell {
 
 impl HistoryCell for AgentMessageCell {
     fn display_lines(&self, width: u16) -> Vec<Line<'static>> {
-        adaptive_wrap_lines(
-            &self.lines,
-            RtOptions::new(width as usize)
-                .initial_indent(if self.is_first_line {
-                    "• ".dim().into()
-                } else {
-                    "  ".into()
-                })
-                .subsequent_indent("  ".into()),
-        )
+        let mut wrapped = Vec::new();
+        for (index, line) in self.lines.iter().enumerate() {
+            let initial_indent = if index == 0 && self.is_first_line {
+                "• ".dim().into()
+            } else {
+                "  ".into()
+            };
+            let mut subsequent_indent = Line::from("  ");
+            subsequent_indent
+                .spans
+                .extend(crate::insert_history::leading_whitespace_prefix(line).spans);
+            let line_wrapped = adaptive_wrap_line(
+                line,
+                RtOptions::new(width as usize)
+                    .initial_indent(initial_indent)
+                    .subsequent_indent(subsequent_indent),
+            );
+            push_owned_lines(&line_wrapped, &mut wrapped);
+        }
+        wrapped
     }
 
     fn raw_lines(&self) -> Vec<Line<'static>> {

--- a/codex-rs/tui/src/history_cell/mod.rs
+++ b/codex-rs/tui/src/history_cell/mod.rs
@@ -54,6 +54,7 @@ use codex_app_server_protocol::McpServerStatusDetail;
 use codex_app_server_protocol::ToolRequestUserInputAnswer;
 use codex_app_server_protocol::ToolRequestUserInputQuestion;
 use codex_app_server_protocol::WebSearchAction;
+#[cfg(test)]
 use codex_config::types::McpServerTransportConfig;
 #[cfg(test)]
 use codex_mcp::qualified_mcp_tool_name_prefix;
@@ -75,6 +76,7 @@ use codex_protocol::plan_tool::StepStatus;
 use codex_protocol::plan_tool::UpdatePlanArgs;
 use codex_protocol::user_input::TextElement;
 use codex_utils_absolute_path::AbsolutePathBuf;
+#[cfg(test)]
 use codex_utils_cli::format_env_display;
 use image::DynamicImage;
 use image::ImageReader;

--- a/codex-rs/tui/src/history_cell/snapshots/codex_tui__history_cell__tests__mcp_tools_output_from_statuses_renders_status_only_servers.snap
+++ b/codex-rs/tui/src/history_cell/snapshots/codex_tui__history_cell__tests__mcp_tools_output_from_statuses_renders_status_only_servers.snap
@@ -1,5 +1,5 @@
 ---
-source: tui/src/history_cell.rs
+source: tui/src/history_cell/tests.rs
 expression: rendered
 ---
 /mcp
@@ -8,5 +8,4 @@ expression: rendered
 
   • plugin_docs
     • Auth: Unsupported
-    • Command: docs-server --stdio
     • Tools: lookup

--- a/codex-rs/tui/src/history_cell/snapshots/codex_tui__history_cell__tests__mcp_tools_output_from_statuses_renders_verbose_inventory.snap
+++ b/codex-rs/tui/src/history_cell/snapshots/codex_tui__history_cell__tests__mcp_tools_output_from_statuses_renders_verbose_inventory.snap
@@ -1,5 +1,5 @@
 ---
-source: tui/src/history_cell.rs
+source: tui/src/history_cell/tests.rs
 expression: rendered
 ---
 /mcp
@@ -7,9 +7,7 @@ expression: rendered
 🔌  MCP Tools
 
   • plugin_docs
-    • Status: enabled
     • Auth: Unsupported
-    • Command: docs-server --stdio
     • Tools: lookup
     • Resources: Docs (file:///docs)
     • Resource templates: Doc Template (file:///docs/{id})

--- a/codex-rs/tui/src/history_cell/snapshots/codex_tui__history_cell__tests__streamed_agent_list_paragraph_preserves_item_indent_when_wrapped.snap
+++ b/codex-rs/tui/src/history_cell/snapshots/codex_tui__history_cell__tests__streamed_agent_list_paragraph_preserves_item_indent_when_wrapped.snap
@@ -1,0 +1,10 @@
+---
+source: tui/src/history_cell/tests.rs
+expression: "lines.join(\"\\n\")"
+---
+• 1. Correctness issue: server tool-search completions are
+  rejected.
+  
+     In next_prompt_suggestion.rs, ToolSearchCall records its
+     call id, but a paired output is ignored and suppresses
+     suggestions.

--- a/codex-rs/tui/src/history_cell/tests.rs
+++ b/codex-rs/tui/src/history_cell/tests.rs
@@ -11,7 +11,6 @@ use crate::wrapping::word_wrap_lines;
 use codex_app_server_protocol::AskForApproval;
 use codex_app_server_protocol::McpAuthStatus;
 use codex_config::types::McpServerConfig;
-use codex_config::types::McpServerDisabledReason;
 use codex_otel::RuntimeMetricTotals;
 use codex_otel::RuntimeMetricsSummary;
 use codex_protocol::ThreadId;
@@ -803,19 +802,8 @@ async fn mcp_tools_output_lists_tools_for_hyphenated_server_names() {
     insta::assert_snapshot!(rendered);
 }
 
-#[tokio::test]
-async fn mcp_tools_output_from_statuses_renders_status_only_servers() {
-    let mut config = test_config().await;
-    let mut plugin_docs =
-        stdio_server_config("docs-server", vec!["--stdio"], /*env*/ None, vec![]);
-    plugin_docs.enabled = false;
-    plugin_docs.disabled_reason = Some(McpServerDisabledReason::Unknown);
-    let servers = HashMap::from([("plugin_docs".to_string(), plugin_docs)]);
-    config
-        .mcp_servers
-        .set(servers)
-        .expect("test mcp servers should accept any configuration");
-
+#[test]
+fn mcp_tools_output_from_statuses_renders_status_only_servers() {
     let statuses = vec![McpServerStatus {
         name: "plugin_docs".to_string(),
         tools: HashMap::from([(
@@ -836,27 +824,15 @@ async fn mcp_tools_output_from_statuses_renders_status_only_servers() {
         auth_status: codex_app_server_protocol::McpAuthStatus::Unsupported,
     }];
 
-    let cell = new_mcp_tools_output_from_statuses(
-        &config,
-        &statuses,
-        McpServerStatusDetail::ToolsAndAuthOnly,
-    );
+    let cell =
+        new_mcp_tools_output_from_statuses(&statuses, McpServerStatusDetail::ToolsAndAuthOnly);
     let rendered = render_lines(&cell.display_lines(/*width*/ 120)).join("\n");
 
     insta::assert_snapshot!(rendered);
 }
 
-#[tokio::test]
-async fn mcp_tools_output_from_statuses_renders_verbose_inventory() {
-    let mut config = test_config().await;
-    let plugin_docs =
-        stdio_server_config("docs-server", vec!["--stdio"], /*env*/ None, vec![]);
-    let servers = HashMap::from([("plugin_docs".to_string(), plugin_docs)]);
-    config
-        .mcp_servers
-        .set(servers)
-        .expect("test mcp servers should accept any configuration");
-
+#[test]
+fn mcp_tools_output_from_statuses_renders_verbose_inventory() {
     let statuses = vec![McpServerStatus {
         name: "plugin_docs".to_string(),
         tools: HashMap::from([(
@@ -894,7 +870,7 @@ async fn mcp_tools_output_from_statuses_renders_verbose_inventory() {
         auth_status: codex_app_server_protocol::McpAuthStatus::Unsupported,
     }];
 
-    let cell = new_mcp_tools_output_from_statuses(&config, &statuses, McpServerStatusDetail::Full);
+    let cell = new_mcp_tools_output_from_statuses(&statuses, McpServerStatusDetail::Full);
     let rendered = render_lines(&cell.display_lines(/*width*/ 120)).join("\n");
 
     insta::assert_snapshot!(rendered);

--- a/codex-rs/tui/src/history_cell/tests.rs
+++ b/codex-rs/tui/src/history_cell/tests.rs
@@ -2295,6 +2295,30 @@ fn agent_markdown_cell_does_not_split_words_after_inline_markdown() {
 }
 
 #[test]
+fn streamed_agent_list_paragraph_preserves_item_indent_when_wrapped() {
+    let cell = AgentMessageCell::new(
+        vec![
+            Line::from("1. Correctness issue: server tool-search completions are rejected."),
+            Line::default(),
+            Line::from(
+                "   In next_prompt_suggestion.rs, ToolSearchCall records its call id, but a paired output is ignored and suppresses suggestions.",
+            ),
+        ],
+        /*is_first_line*/ true,
+    );
+
+    let lines = render_lines(&cell.display_lines(/*width*/ 64));
+    assert!(
+        lines
+            .iter()
+            .filter(|line| line.contains("paired output") || line.contains("suggestions."))
+            .all(|line| line.starts_with("     ")),
+        "expected all wrapped paragraph rows to retain the assistant gutter and list indent: {lines:?}",
+    );
+    insta::assert_snapshot!(lines.join("\n"));
+}
+
+#[test]
 fn agent_markdown_cell_narrow_width_shows_prefix_only() {
     let source = "narrow width coverage\n";
     let cell = AgentMarkdownCell::new(source.to_string(), &test_cwd());

--- a/codex-rs/tui/src/insert_history.rs
+++ b/codex-rs/tui/src/insert_history.rs
@@ -166,7 +166,7 @@ where
     Ok(())
 }
 
-fn leading_whitespace_prefix(line: &Line<'_>) -> Line<'static> {
+pub(crate) fn leading_whitespace_prefix(line: &Line<'_>) -> Line<'static> {
     let mut spans = Vec::new();
     for span in &line.spans {
         let prefix_end = span

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -1706,11 +1706,25 @@ async fn run_ratatui_app(
         },
     };
 
-    let startup_hooks_browser =
-        match maybe_run_startup_hooks_review(&mut app_server, &mut tui, &config).await? {
-            StartupHooksReviewOutcome::Continue => None,
-            StartupHooksReviewOutcome::OpenHooksBrowser(data) => Some(data),
-        };
+    // Persistent app-server resumes may attach to an already-running thread,
+    // where resume config overrides are ignored.
+    let is_persistent_resume = !matches!(&app_server_target, AppServerTarget::Embedded)
+        && matches!(
+            &session_selection,
+            resume_picker::SessionSelection::Resume(_)
+        );
+    let bypass_hook_trust_for_startup_review = config.bypass_hook_trust && !is_persistent_resume;
+    let startup_hooks_browser = match maybe_run_startup_hooks_review(
+        &mut app_server,
+        &mut tui,
+        &config,
+        bypass_hook_trust_for_startup_review,
+    )
+    .await?
+    {
+        StartupHooksReviewOutcome::Continue => None,
+        StartupHooksReviewOutcome::OpenHooksBrowser(data) => Some(data),
+    };
 
     let app_result = App::run(
         &mut tui,

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -1425,7 +1425,7 @@ async fn run_ratatui_app(
                 exit_reason: ExitReason::UserRequested,
             });
         }
-        trust_decision_was_made = onboarding_result.directory_trust_decision.is_some();
+        trust_decision_was_made = onboarding_result.directory_trust_persisted;
         // If this onboarding run included the login step, always refresh cloud requirements and
         // rebuild config. This avoids missing newly available cloud requirements due to login
         // status detection edge cases.
@@ -1441,7 +1441,7 @@ async fn run_ratatui_app(
 
         // If the user made an explicit trust decision, or we showed the login flow, reload config
         // so current process state reflects persisted trust/auth changes.
-        if onboarding_result.directory_trust_decision.is_some()
+        if onboarding_result.directory_trust_persisted
             || (show_login_screen && !uses_remote_workspace)
         {
             load_config_or_exit(

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -1312,6 +1312,7 @@ async fn run_ratatui_app(
     let mut tui = Tui::new(
         initialized_terminal.terminal,
         initialized_terminal.enhanced_keys_supported,
+        initialized_terminal.stderr_guard,
     );
     let mut terminal_restore_guard = TerminalRestoreGuard::new();
 

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -1002,6 +1002,7 @@ pub async fn run_main(
     )
     .await;
 
+    let mut manually_selected_oss_provider = None;
     let model_provider_override = if cli.oss {
         let resolved = resolve_oss_provider(cli.oss_provider.as_deref(), &config_toml);
 
@@ -1009,11 +1010,15 @@ pub async fn run_main(
             Some(provider)
         } else {
             // No provider configured, prompt the user
-            let provider = oss_selection::select_oss_provider(&codex_home).await?;
+            let selection = oss_selection::select_oss_provider().await?;
+            let provider = selection.provider;
             if provider == "__CANCELLED__" {
                 return Err(std::io::Error::other(
                     "OSS provider selection was cancelled by user",
                 ));
+            }
+            if selection.manually_selected {
+                manually_selected_oss_provider = Some(provider.clone());
             }
             Some(provider)
         }
@@ -1256,6 +1261,7 @@ pub async fn run_main(
         app_server_target,
         remote_cwd_override,
         config,
+        manually_selected_oss_provider,
         overrides,
         cli_kv_overrides,
         cloud_requirements,
@@ -1277,6 +1283,7 @@ async fn run_ratatui_app(
     app_server_target: AppServerTarget,
     remote_cwd_override: Option<PathBuf>,
     initial_config: Config,
+    manually_selected_oss_provider: Option<String>,
     overrides: ConfigOverrides,
     cli_kv_overrides: Vec<(String, toml::Value)>,
     mut cloud_requirements: CloudRequirementsLoader,
@@ -1356,6 +1363,19 @@ async fn run_ratatui_app(
         }
     }
     .with_remote_cwd_override(remote_cwd_override.clone());
+    if let Some(provider) = manually_selected_oss_provider.as_deref()
+        && let Err(err) = config_update::write_config_batch(
+            app_server_session.request_handle(),
+            vec![config_update::build_oss_provider_edit(provider)],
+        )
+        .await
+    {
+        warn!(
+            %err,
+            provider,
+            "Failed to persist selected OSS provider preference"
+        );
+    }
     let mut app_server = Some(app_server_session);
 
     let should_show_trust_screen_flag =

--- a/codex-rs/tui/src/markdown_render.rs
+++ b/codex-rs/tui/src/markdown_render.rs
@@ -20,7 +20,7 @@
 //!    artifacts of pulldown-cmark's lenient parsing.
 //! 2. **Normalize column counts** -- pad or truncate so every row matches the
 //!    alignment count.
-//! 3. **Compute column widths** -- allocate widths with Narrative/Structured
+//! 3. **Compute column widths** -- allocate widths with content-aware
 //!    priority and iterative shrinking.
 //! 4. **Render box grid** -- Unicode borders (`┌───┬───┐`) or fallback to pipe
 //!    format when the minimum cannot fit.
@@ -29,12 +29,12 @@
 //!
 //! ## Width allocation
 //!
-//! Columns are classified as Narrative (long prose, >= 4 avg words or >= 28
-//! avg char width) or Structured (short tokens).  The shrink loop removes
-//! one character at a time, preferring Narrative columns, until the total
-//! fits the available width.  A guard cost penalises shrinking below a
-//! column's header token width.  When even 3-char-wide columns cannot fit,
-//! the table falls back to pipe-delimited format.
+//! Columns are classified as Narrative (long prose), TokenHeavy (paths, URLs,
+//! or hashes), or Compact (short values such as counts and status labels).
+//! Token-heavy columns give up excess width before narrative columns so an
+//! oversized path does not collapse readable prose; compact values are
+//! preserved last.  When even 3-char-wide columns cannot fit, the table falls
+//! back to pipe-delimited format.
 
 use crate::render::highlight::highlight_code_to_lines;
 use crate::render::line_utils::line_to_static;
@@ -219,18 +219,16 @@ struct RenderedTableLines {
 
 /// Classification of a table column for width-allocation priority.
 ///
-/// Narrative columns (long prose, many words per cell) are shrunk first when the table exceeds
-/// available width.  Structured columns (short tokens like dates, status words, numbers) are
-/// preserved as long as possible to keep their content on a single line.
-///
-/// The heuristic is simple: >= 4 average words per cell OR >= 28 average character width →
-/// Narrative. Everything else → Structured.
+/// Token-heavy columns such as paths and URLs are allowed to wrap before prose becomes unreadable.
+/// Compact columns such as counts or status words resist wrapping so their values stay scannable.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum TableColumnKind {
     /// Long-form prose content (>= 4 avg words/cell or >= 28 avg char width).
     Narrative,
-    /// Short, token-like content that should resist wrapping.
-    Structured,
+    /// Content dominated by long tokens, such as paths, URLs, and hashes.
+    TokenHeavy,
+    /// Short values, such as counts and status labels, that should resist wrapping.
+    Compact,
 }
 
 /// Per-column statistics used to drive the width-allocation algorithm.
@@ -245,11 +243,7 @@ struct TableColumnMetrics {
     header_token_width: usize,
     /// Display width of the longest whitespace-delimited token across body rows.
     body_token_width: usize,
-    /// Average number of whitespace-delimited words per non-empty body cell.
-    avg_words_per_cell: f64,
-    /// Average display width of non-empty body cells.
-    avg_cell_width: f64,
-    /// Classification derived from `avg_words_per_cell` and `avg_cell_width`.
+    /// Classification derived from body token density and average cell content.
     kind: TableColumnKind,
 }
 
@@ -1099,9 +1093,9 @@ where
     ///
     /// Each column starts at its natural (max cell content) width, then columns
     /// are iteratively shrunk one character at a time until the total fits within
-    /// `available_width`. Narrative columns (long prose) are shrunk before
-    /// Structured columns (short tokens). Returns `None` when even the minimum
-    /// width (3 chars per column) cannot fit.
+    /// `available_width`. Token-heavy columns surrender excess width before
+    /// narrative prose; compact columns are preserved last. Returns `None` when
+    /// even the minimum width (3 chars per column) cannot fit.
     fn compute_column_widths(
         &self,
         header: &[TableCell],
@@ -1130,19 +1124,17 @@ where
             .collect();
         let mut floor_total: usize = floors.iter().sum();
         if floor_total > max_width {
-            // Relax preferred floors (starting with narrative columns) until we can satisfy the
-            // width budget. We still keep hard minimums.
+            // Relax preferred floors in wrapping priority order until the hard width budget fits.
             while floor_total > max_width {
                 let Some((idx, _)) = floors
                     .iter()
                     .enumerate()
                     .filter(|(_, floor)| **floor > min_column_width)
                     .min_by_key(|(idx, floor)| {
-                        let kind_priority = match metrics[*idx].kind {
-                            TableColumnKind::Narrative => 0,
-                            TableColumnKind::Structured => 1,
-                        };
-                        (kind_priority, *floor)
+                        (
+                            Self::column_shrink_priority(metrics[*idx].kind),
+                            usize::MAX.saturating_sub(**floor),
+                        )
                     })
                 else {
                     break;
@@ -1182,6 +1174,8 @@ where
             let header_token_width = Self::longest_token_width(&header_plain);
             let mut max_width = Self::cell_display_width(header_cell);
             let mut body_token_width = 0usize;
+            let mut body_token_count = 0usize;
+            let mut long_body_token_count = 0usize;
             let mut total_words = 0usize;
             let mut total_cells = 0usize;
             let mut total_cell_width = 0usize;
@@ -1193,6 +1187,11 @@ where
                 body_token_width = body_token_width.max(Self::longest_token_width(&plain));
                 let word_count = plain.split_whitespace().count();
                 if word_count > 0 {
+                    body_token_count += word_count;
+                    long_body_token_count += plain
+                        .split_whitespace()
+                        .filter(|token| token.width() >= 20)
+                        .count();
                     total_words += word_count;
                     total_cells += 1;
                     total_cell_width += plain.width();
@@ -1209,22 +1208,20 @@ where
             } else {
                 total_cell_width as f64 / total_cells as f64
             };
-            let kind = if body_token_width >= 20 && avg_words_per_cell <= 2.0 {
-                // URL-like/token-heavy columns should resist collapse even if their
-                // average cell width is high.
-                TableColumnKind::Structured
+            let kind = if long_body_token_count > 0
+                && long_body_token_count >= body_token_count.saturating_sub(long_body_token_count)
+            {
+                TableColumnKind::TokenHeavy
             } else if avg_words_per_cell >= 4.0 || avg_cell_width >= 28.0 {
                 TableColumnKind::Narrative
             } else {
-                TableColumnKind::Structured
+                TableColumnKind::Compact
             };
 
             metrics.push(TableColumnMetrics {
                 max_width,
                 header_token_width,
                 body_token_width,
-                avg_words_per_cell,
-                avg_cell_width,
                 kind,
             });
         }
@@ -1235,13 +1232,13 @@ where
     /// Compute the preferred minimum width for a column before the shrink loop
     /// starts reducing it further.
     ///
-    /// Narrative columns floor at the header's longest token (capped at 10).
-    /// Structured columns floor at the larger of the header and body token widths
+    /// Narrative and token-heavy columns retain a readable 16-cell soft floor.
+    /// Compact columns floor at the larger of the header and body token widths
     /// (body capped at 16). The result is clamped to `[min_column_width, max_width]`.
     fn preferred_column_floor(metrics: &TableColumnMetrics, min_column_width: usize) -> usize {
         let token_target = match metrics.kind {
-            TableColumnKind::Narrative => metrics.header_token_width.min(10),
-            TableColumnKind::Structured => metrics
+            TableColumnKind::Narrative | TableColumnKind::TokenHeavy => 16,
+            TableColumnKind::Compact => metrics
                 .header_token_width
                 .max(metrics.body_token_width.min(16)),
         };
@@ -1250,10 +1247,9 @@ where
 
     /// Pick the next column to shrink by one character during width allocation.
     ///
-    /// Priority: Narrative columns are shrunk before Structured. Within the same
-    /// kind, the column with the most slack above its floor is chosen. A guard
-    /// cost is added when the width would fall below the header's longest token
-    /// (to avoid truncating column headers).
+    /// Priority: TokenHeavy columns are shrunk before Narrative, then Compact.
+    /// Within the same kind, the column with the most slack above its floor is
+    /// chosen so similarly-shaped columns stay balanced.
     fn next_column_to_shrink(
         widths: &[usize],
         floors: &[usize],
@@ -1265,28 +1261,20 @@ where
             .filter(|(idx, width)| **width > floors[*idx])
             .min_by_key(|(idx, width)| {
                 let slack = width.saturating_sub(floors[*idx]);
-                let kind_cost = match metrics[*idx].kind {
-                    TableColumnKind::Narrative => 0i32,
-                    TableColumnKind::Structured => 2i32,
-                };
-                let header_guard = if **width <= metrics[*idx].header_token_width {
-                    3i32
-                } else {
-                    0i32
-                };
-                let density_guard = if metrics[*idx].avg_words_per_cell >= 4.0
-                    || metrics[*idx].avg_cell_width >= 24.0
-                {
-                    0i32
-                } else {
-                    1i32
-                };
                 (
-                    kind_cost + header_guard + density_guard,
+                    Self::column_shrink_priority(metrics[*idx].kind),
                     usize::MAX.saturating_sub(slack),
                 )
             })
             .map(|(idx, _)| idx)
+    }
+
+    fn column_shrink_priority(kind: TableColumnKind) -> usize {
+        match kind {
+            TableColumnKind::TokenHeavy => 0,
+            TableColumnKind::Narrative => 1,
+            TableColumnKind::Compact => 2,
+        }
     }
 
     fn render_border_line(
@@ -2203,7 +2191,7 @@ mod tests {
 
     #[test]
     fn column_classification_narrative_by_word_count() {
-        // Col 0: short tokens (1-2 words each) → Structured
+        // Col 0: short tokens (1-2 words each) -> Compact
         // Col 1: prose (≥4 words per cell) → Narrative
         let header = vec![make_cell("ID"), make_cell("Description")];
         let rows = vec![
@@ -2211,72 +2199,87 @@ mod tests {
             vec![make_cell("2"), make_cell("another verbose body cell here")],
         ];
         let metrics = W::collect_table_column_metrics(&header, &rows, /*column_count*/ 2);
-        assert_eq!(metrics[0].kind, TableColumnKind::Structured);
+        assert_eq!(metrics[0].kind, TableColumnKind::Compact);
         assert_eq!(metrics[1].kind, TableColumnKind::Narrative);
     }
 
     #[test]
-    fn column_classification_structured_by_url_like_token() {
-        // Col with short word count but ≥28 avg char width and long tokens → Structured
-        // (URL-like/token-heavy columns resist collapse)
+    fn column_classification_token_heavy_by_url_like_tokens() {
         let header = vec![make_cell("URL")];
         let rows = vec![
             vec![make_cell("https://example.com/very/long/path")],
             vec![make_cell("https://another.example.org/deep")],
         ];
         let metrics = W::collect_table_column_metrics(&header, &rows, /*column_count*/ 1);
-        assert!(metrics[0].avg_cell_width >= 28.0);
-        assert_eq!(metrics[0].kind, TableColumnKind::Structured);
+        assert_eq!(metrics[0].kind, TableColumnKind::TokenHeavy);
     }
 
     #[test]
-    fn column_classification_structured_all_short() {
-        // Both columns short tokens → both Structured
+    fn column_classification_token_heavy_for_local_path_lists() {
+        let header = vec![make_cell("Files")];
+        let rows = vec![
+            vec![make_cell(
+                "codex-rs/core/src/next_prompt_suggestion.rs:1, codex-rs/core/src/next_prompt_suggestion_tests.rs:1",
+            )],
+            vec![make_cell(
+                "codex-rs/core/src/context/next_prompt_suggestion.rs:1, codex-rs/core/src/context/contextual_user_message_tests.rs:1",
+            )],
+        ];
+        let metrics = W::collect_table_column_metrics(&header, &rows, /*column_count*/ 1);
+        assert_eq!(metrics[0].kind, TableColumnKind::TokenHeavy);
+    }
+
+    #[test]
+    fn column_classification_compact_all_short() {
+        // Both columns short tokens -> both Compact
         let header = vec![make_cell("Status"), make_cell("Count")];
         let rows = vec![
             vec![make_cell("ok"), make_cell("42")],
             vec![make_cell("err"), make_cell("7")],
         ];
         let metrics = W::collect_table_column_metrics(&header, &rows, /*column_count*/ 2);
-        assert_eq!(metrics[0].kind, TableColumnKind::Structured);
-        assert_eq!(metrics[1].kind, TableColumnKind::Structured);
+        assert_eq!(metrics[0].kind, TableColumnKind::Compact);
+        assert_eq!(metrics[1].kind, TableColumnKind::Compact);
     }
 
     #[test]
-    fn preferred_floor_narrative_caps_header_at_10() {
-        // Narrative col: header_token_width 15 → floors at 10
+    fn preferred_floor_narrative_retains_readable_width() {
         let m = TableColumnMetrics {
             max_width: 40,
             header_token_width: 15,
             body_token_width: 8,
-            avg_words_per_cell: 5.0,
-            avg_cell_width: 30.0,
             kind: TableColumnKind::Narrative,
         };
-        assert_eq!(W::preferred_column_floor(&m, /*min_column_width*/ 3), 10);
+        assert_eq!(W::preferred_column_floor(&m, /*min_column_width*/ 3), 16);
 
-        // Narrative col: header_token_width 6 → floors at 6 (below cap)
         let m2 = TableColumnMetrics {
-            max_width: 40,
+            max_width: 12,
             header_token_width: 6,
             body_token_width: 8,
-            avg_words_per_cell: 5.0,
-            avg_cell_width: 30.0,
             kind: TableColumnKind::Narrative,
         };
-        assert_eq!(W::preferred_column_floor(&m2, /*min_column_width*/ 3), 6);
+        assert_eq!(W::preferred_column_floor(&m2, /*min_column_width*/ 3), 12);
     }
 
     #[test]
-    fn preferred_floor_structured_uses_body_token() {
-        // Structured: max(header_token_width, body_token_width.min(16))
+    fn preferred_floor_token_heavy_retains_readable_width() {
+        let m = TableColumnMetrics {
+            max_width: 80,
+            header_token_width: 5,
+            body_token_width: 60,
+            kind: TableColumnKind::TokenHeavy,
+        };
+        assert_eq!(W::preferred_column_floor(&m, /*min_column_width*/ 3), 16);
+    }
+
+    #[test]
+    fn preferred_floor_compact_uses_body_token() {
+        // Compact: max(header_token_width, body_token_width.min(16))
         let m = TableColumnMetrics {
             max_width: 30,
             header_token_width: 5,
             body_token_width: 12,
-            avg_words_per_cell: 1.0,
-            avg_cell_width: 10.0,
-            kind: TableColumnKind::Structured,
+            kind: TableColumnKind::Compact,
         };
         // max(5, min(12, 16)) = max(5, 12) = 12
         assert_eq!(W::preferred_column_floor(&m, /*min_column_width*/ 3), 12);
@@ -2286,40 +2289,46 @@ mod tests {
             max_width: 30,
             header_token_width: 5,
             body_token_width: 20,
-            avg_words_per_cell: 1.0,
-            avg_cell_width: 10.0,
-            kind: TableColumnKind::Structured,
+            kind: TableColumnKind::Compact,
         };
         // max(5, min(20, 16)) = max(5, 16) = 16
         assert_eq!(W::preferred_column_floor(&m2, /*min_column_width*/ 3), 16);
     }
 
     #[test]
-    fn next_column_to_shrink_prefers_narrative() {
-        // Two columns: Narrative (col 0) and Structured (col 1), both with slack.
-        // Narrative should be shrunk first.
-        let widths = [20usize, 20];
-        let floors = [8usize, 8];
+    fn next_column_to_shrink_prefers_token_heavy_then_narrative() {
+        let widths = [20usize, 20, 20];
+        let floors = [8usize, 8, 8];
         let metrics = [
             TableColumnMetrics {
                 max_width: 30,
                 header_token_width: 8,
                 body_token_width: 6,
-                avg_words_per_cell: 5.0,
-                avg_cell_width: 30.0,
                 kind: TableColumnKind::Narrative,
             },
             TableColumnMetrics {
                 max_width: 30,
                 header_token_width: 8,
+                body_token_width: 28,
+                kind: TableColumnKind::TokenHeavy,
+            },
+            TableColumnMetrics {
+                max_width: 30,
+                header_token_width: 8,
                 body_token_width: 6,
-                avg_words_per_cell: 1.0,
-                avg_cell_width: 10.0,
-                kind: TableColumnKind::Structured,
+                kind: TableColumnKind::Compact,
             },
         ];
         let idx = W::next_column_to_shrink(&widths, &floors, &metrics);
-        assert_eq!(idx, Some(0), "Narrative column should be shrunk first");
+        assert_eq!(idx, Some(1), "token-heavy column should shrink first");
+
+        let widths = [20usize, 8, 20];
+        let idx = W::next_column_to_shrink(&widths, &floors, &metrics);
+        assert_eq!(
+            idx,
+            Some(0),
+            "narrative column should shrink before compact"
+        );
     }
 
     // ===== Spillover-detection unit tests =====

--- a/codex-rs/tui/src/markdown_render.rs
+++ b/codex-rs/tui/src/markdown_render.rs
@@ -336,7 +336,7 @@ where
     indent_stack: Vec<IndentContext>,
     list_indices: Vec<Option<u64>>,
     list_needs_blank_before_next_item: Vec<bool>,
-    list_item_contains_code_block: Vec<bool>,
+    list_item_start_line_counts: Vec<usize>,
     link: Option<LinkState>,
     needs_newline: bool,
     pending_marker_line: bool,
@@ -370,7 +370,7 @@ where
             indent_stack: Vec::new(),
             list_indices: Vec::new(),
             list_needs_blank_before_next_item: Vec::new(),
-            list_item_contains_code_block: Vec::new(),
+            list_item_start_line_counts: Vec::new(),
             link: None,
             needs_newline: false,
             pending_marker_line: false,
@@ -480,7 +480,9 @@ where
             TagEnd::CodeBlock => self.end_codeblock(),
             TagEnd::List(_) => self.end_list(),
             TagEnd::Item => {
-                if self.list_item_contains_code_block.pop().unwrap_or(false)
+                self.flush_current_line();
+                let start_line_count = self.list_item_start_line_counts.pop().unwrap_or_default();
+                if self.text.lines.len().saturating_sub(start_line_count) > 1
                     && let Some(needs_blank) = self.list_needs_blank_before_next_item.last_mut()
                 {
                     *needs_blank = true;
@@ -737,8 +739,9 @@ where
         {
             self.push_blank_line();
         }
+        self.flush_current_line();
+        self.list_item_start_line_counts.push(self.text.lines.len());
         self.pending_marker_line = true;
-        self.list_item_contains_code_block.push(false);
         let depth = self.list_indices.len();
         let is_ordered = self
             .list_indices
@@ -778,9 +781,6 @@ where
     }
 
     fn start_codeblock(&mut self, lang: Option<String>, indent: Option<Span<'static>>) {
-        for item_contains_code_block in &mut self.list_item_contains_code_block {
-            *item_contains_code_block = true;
-        }
         self.flush_current_line();
         if !self.text.lines.is_empty() {
             self.push_blank_line();

--- a/codex-rs/tui/src/markdown_render_tests.rs
+++ b/codex-rs/tui/src/markdown_render_tests.rs
@@ -531,6 +531,7 @@ fn nested_unordered_in_ordered() {
         Line::from_iter(["1. ".light_blue(), "Outer".into()]),
         Line::from_iter(["    - ", "Inner A"]),
         Line::from_iter(["    - ", "Inner B"]),
+        Line::default(),
         Line::from_iter(["2. ".light_blue(), "Next".into()]),
     ]);
     assert_eq!(text, expected);
@@ -544,6 +545,7 @@ fn nested_ordered_in_unordered() {
         Line::from_iter(["- ", "Outer"]),
         Line::from_iter(["    1. ".light_blue(), "One".into()]),
         Line::from_iter(["    2. ".light_blue(), "Two".into()]),
+        Line::default(),
         Line::from_iter(["- ", "Last"]),
     ]);
     assert_eq!(text, expected);
@@ -557,6 +559,7 @@ fn loose_list_item_multiple_paragraphs() {
         Line::from_iter(["1. ".light_blue(), "First paragraph".into()]),
         Line::default(),
         Line::from_iter(["   ", "Second paragraph of same item"]),
+        Line::default(),
         Line::from_iter(["2. ".light_blue(), "Next item".into()]),
     ]);
     assert_eq!(text, expected);
@@ -581,6 +584,7 @@ fn deeply_nested_mixed_three_levels() {
         Line::from_iter(["1. ".light_blue(), "A".into()]),
         Line::from_iter(["    - ", "B"]),
         Line::from_iter(["        1. ".light_blue(), "C".into()]),
+        Line::default(),
         Line::from_iter(["2. ".light_blue(), "D".into()]),
     ]);
     assert_eq!(text, expected);
@@ -1182,6 +1186,42 @@ fn list_item_after_simple_item_stays_compact() {
 }
 
 #[test]
+fn multiline_finding_items_are_separated_snapshot() {
+    let md = r#"**Findings**
+
+1. **Correctness issue: server tool-search completions are always rejected.**
+
+   In `next_prompt_suggestion.rs`, the output is ignored, suppressing suggestions after completed searches.
+
+   Minimal correction: count matching outputs and suppress only missing ones.
+
+2. **High-confidence simplification: remove the unused error channel.**
+
+   The implementation resolves failures to `None`, so its contract can be narrower.
+
+3. **High-confidence churn reduction: consolidate table-driven filter tests.**
+"#;
+    let text = render_markdown_text(md);
+    assert_snapshot!(plain_lines(&text).join("\n"));
+}
+
+#[test]
+fn wrapped_list_item_is_separated_from_next_sibling() {
+    let md = "1. This item wraps onto another visible rendered line\n2. Next item\n";
+    let text = render_markdown_text_with_width(md, Some(/*width*/ 24));
+    assert_eq!(
+        plain_lines(&text),
+        vec![
+            "1. This item wraps onto",
+            "   another visible",
+            "   rendered line",
+            "",
+            "2. Next item",
+        ]
+    );
+}
+
+#[test]
 fn mixed_url_markdown_wraps_prose_without_splitting_words_snapshot() {
     let md = "This paragraph keeps **strikethrough** intact near a [link](https://example.com/path) while enough surrounding prose forces wrapping.";
     let text = render_markdown_text_with_width(md, Some(/*width*/ 48));
@@ -1391,6 +1431,7 @@ fn nested_item_continuation_paragraph_is_indented() {
         Line::from_iter(["    - ", "B"]),
         Line::default(),
         Line::from_iter(["      ", "Continuation for B"]),
+        Line::default(),
         Line::from_iter(["2. ".light_blue(), "C".into()]),
     ]);
     assert_eq!(text, expected);

--- a/codex-rs/tui/src/markdown_render_tests.rs
+++ b/codex-rs/tui/src/markdown_render_tests.rs
@@ -1486,6 +1486,22 @@ fn table_wraps_cell_content_when_width_is_narrow() {
 }
 
 #[test]
+fn table_wraps_file_paths_before_collapsing_narrative_columns_snapshot() {
+    let md = r#"| Unit | Files | Adds | Removes | What It Adds |
+|---|---:|---:|---:|---|
+| Suggestion engine and unit coverage | [next_prompt_suggestion.rs](/Users/example/code/codex/codex-rs/core/src/next_prompt_suggestion.rs:1), [next_prompt_suggestion_tests.rs](/Users/example/code/codex/codex-rs/core/src/next_prompt_suggestion_tests.rs:1) | 704 | 0 | Sampling workflow, stable-history checks, tool-flow suppression, fast reasoning profile, filtering rules, cancellation and timeout. |
+| Model instruction fragment and contextual isolation | [next_prompt_suggestion.rs](/Users/example/code/codex/codex-rs/core/src/context/next_prompt_suggestion.rs:1), [contextual_user_message_tests.rs](/Users/example/code/codex/codex-rs/core/src/context/contextual_user_message_tests.rs:1) | 54 | 0 | Synthetic suggestion prompt and an isolation test for ordinary user text. |
+"#;
+    let text = render_markdown_text_with_width_and_cwd(
+        md,
+        Some(/*width*/ 120),
+        Some(Path::new("/Users/example/code/codex")),
+    );
+
+    assert_snapshot!(plain_lines(&text).join("\n"));
+}
+
+#[test]
 fn table_inside_blockquote_has_quote_prefix() {
     let md = "> | A | B |\n> |---|---|\n> | 1 | 2 |\n";
     let text = render_markdown_text(md);

--- a/codex-rs/tui/src/markdown_stream.rs
+++ b/codex-rs/tui/src/markdown_stream.rs
@@ -789,6 +789,7 @@ mod tests {
             "3. Loose item with its own paragraph.".to_string(),
             "".to_string(),
             "   This paragraph belongs to the same list item.".to_string(),
+            "".to_string(),
             "4. Second loose item with a nested list after a blank line.".to_string(),
             "    - Nested bullet under a loose item".to_string(),
             "    - Another nested bullet".to_string(),

--- a/codex-rs/tui/src/onboarding/onboarding_screen.rs
+++ b/codex-rs/tui/src/onboarding/onboarding_screen.rs
@@ -32,6 +32,7 @@ use codex_protocol::config_types::ForcedLoginMethod;
 
 use crate::LoginStatus;
 use crate::app_server_session::AppServerSession;
+use crate::config_update::write_trusted_project;
 use crate::key_hint::KeyBindingListExt;
 use crate::legacy_core::config::Config;
 #[cfg(target_os = "windows")]
@@ -89,7 +90,7 @@ pub(crate) struct OnboardingScreenArgs {
 }
 
 pub(crate) struct OnboardingResult {
-    pub directory_trust_decision: Option<TrustDirectorySelection>,
+    pub directory_trust_persisted: bool,
     pub should_exit: bool,
 }
 
@@ -111,7 +112,6 @@ impl OnboardingScreen {
             config,
         } = args;
         let cwd = config.cwd.to_path_buf();
-        let codex_home = config.codex_home.to_path_buf();
         let forced_login_method = config.forced_login_method;
         let mut steps: Vec<Step> = Vec::new();
         steps.push(Step::Welcome(WelcomeWidget::new(
@@ -154,7 +154,6 @@ impl OnboardingScreen {
             steps.push(Step::TrustDirectory(TrustDirectoryWidget {
                 cwd,
                 trust_target,
-                codex_home,
                 show_windows_create_sandbox_hint,
                 should_quit: false,
                 selection: None,
@@ -221,19 +220,6 @@ impl OnboardingScreen {
                 .steps
                 .iter()
                 .any(|step| matches!(step.get_step_state(), StepState::InProgress))
-    }
-
-    pub fn directory_trust_decision(&self) -> Option<TrustDirectorySelection> {
-        self.steps
-            .iter()
-            .find_map(|step| {
-                if let Step::TrustDirectory(TrustDirectoryWidget { selection, .. }) = step {
-                    Some(*selection)
-                } else {
-                    None
-                }
-            })
-            .flatten()
     }
 
     pub fn should_exit(&self) -> bool {
@@ -493,7 +479,9 @@ pub(crate) async fn run_onboarding_app(
 ) -> Result<OnboardingResult> {
     use tokio_stream::StreamExt;
 
+    let app_server_request_handle = args.app_server_request_handle.clone();
     let mut onboarding_screen = OnboardingScreen::new(tui, args).await;
+    let mut directory_trust_persisted = false;
     // One-time guard to fully clear the screen after ChatGPT login success message is shown
     let mut did_full_clear_after_success = false;
 
@@ -511,6 +499,13 @@ pub(crate) async fn run_onboarding_app(
                     match event {
                         TuiEvent::Key(key_event) => {
                             onboarding_screen.handle_key_event(key_event);
+                            if !directory_trust_persisted {
+                                directory_trust_persisted = persist_selected_trust(
+                                    &mut onboarding_screen,
+                                    app_server_request_handle.clone(),
+                                )
+                                .await;
+                            }
                         }
                         TuiEvent::Paste(text) => {
                             onboarding_screen.handle_paste(text);
@@ -575,18 +570,73 @@ pub(crate) async fn run_onboarding_app(
         }
     }
     Ok(OnboardingResult {
-        directory_trust_decision: onboarding_screen.directory_trust_decision(),
+        directory_trust_persisted,
         should_exit: onboarding_screen.should_exit(),
     })
+}
+
+async fn persist_selected_trust(
+    onboarding_screen: &mut OnboardingScreen,
+    request_handle: Option<AppServerRequestHandle>,
+) -> bool {
+    let Some((trust_step_index, trust_target)) = onboarding_screen
+        .steps
+        .iter()
+        .enumerate()
+        .find_map(|(index, step)| {
+            if let Step::TrustDirectory(widget) = step
+                && widget.selection == Some(TrustDirectorySelection::Trust)
+            {
+                return Some((index, widget.trust_target.clone()));
+            }
+            None
+        })
+    else {
+        return false;
+    };
+
+    let result = match request_handle {
+        Some(request_handle) => write_trusted_project(request_handle, &trust_target)
+            .await
+            .map(|_| ()),
+        None => Err(color_eyre::eyre::eyre!("app server unavailable")),
+    };
+
+    match result {
+        Ok(()) => true,
+        Err(error) => {
+            tracing::error!(
+                "failed to persist trusted project state for {}: {error:?}",
+                trust_target.display()
+            );
+            if let Step::TrustDirectory(widget) = &mut onboarding_screen.steps[trust_step_index] {
+                widget.selection = None;
+                widget.error = Some(format!(
+                    "Failed to set trust for {}: {error}",
+                    trust_target.display()
+                ));
+            }
+            false
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::ApiKeyEntryContext;
+    use super::OnboardingScreen;
+    use super::Step;
+    use super::StepStateProvider;
+    use super::persist_selected_trust;
     use super::suppress_quit_while_typing_api_key;
+    use crate::onboarding::trust_directory::TrustDirectorySelection;
+    use crate::onboarding::trust_directory::TrustDirectoryWidget;
+    use crate::tui::FrameRequester;
     use crossterm::event::KeyCode;
     use crossterm::event::KeyEvent;
     use crossterm::event::KeyModifiers;
+    use pretty_assertions::assert_eq;
+    use std::path::PathBuf;
 
     #[test]
     fn suppresses_printable_quit_key_during_api_key_entry() {
@@ -634,5 +684,39 @@ mod tests {
             },
         );
         assert!(!suppressed);
+    }
+
+    #[tokio::test]
+    async fn trust_persistence_failure_keeps_trust_step_in_progress() {
+        let mut onboarding_screen = OnboardingScreen {
+            request_frame: FrameRequester::test_dummy(),
+            steps: vec![Step::TrustDirectory(TrustDirectoryWidget {
+                cwd: PathBuf::from("/workspace/project"),
+                trust_target: PathBuf::from("/workspace/project"),
+                show_windows_create_sandbox_hint: false,
+                should_quit: false,
+                selection: Some(TrustDirectorySelection::Trust),
+                highlighted: TrustDirectorySelection::Trust,
+                error: None,
+            })],
+            is_done: false,
+            should_exit: false,
+        };
+
+        let persisted =
+            persist_selected_trust(&mut onboarding_screen, /*request_handle*/ None).await;
+
+        assert!(!persisted);
+        let Step::TrustDirectory(widget) = &onboarding_screen.steps[0] else {
+            panic!("trust step should remain present");
+        };
+        assert_eq!(widget.selection, None);
+        assert_eq!(widget.get_step_state(), super::StepState::InProgress);
+        assert!(
+            widget
+                .error
+                .as_deref()
+                .is_some_and(|error| error.contains("app server unavailable"))
+        );
     }
 }

--- a/codex-rs/tui/src/onboarding/trust_directory.rs
+++ b/codex-rs/tui/src/onboarding/trust_directory.rs
@@ -1,7 +1,5 @@
 use std::path::PathBuf;
 
-use crate::legacy_core::config::set_project_trust_level;
-use codex_protocol::config_types::TrustLevel;
 use crossterm::event::KeyEvent;
 use crossterm::event::KeyEventKind;
 use ratatui::buffer::Buffer;
@@ -24,7 +22,6 @@ use crate::selection_list::selection_option_row;
 
 use super::onboarding_screen::StepState;
 pub(crate) struct TrustDirectoryWidget {
-    pub codex_home: PathBuf,
     pub cwd: PathBuf,
     pub trust_target: PathBuf,
     pub show_windows_create_sandbox_hint: bool,
@@ -166,12 +163,8 @@ impl StepStateProvider for TrustDirectoryWidget {
 
 impl TrustDirectoryWidget {
     fn handle_trust(&mut self) {
-        let target = self.trust_target.clone();
-        if let Err(e) = set_project_trust_level(&self.codex_home, &target, TrustLevel::Trusted) {
-            tracing::error!("Failed to set project trusted: {e:?}");
-            self.error = Some(format!("Failed to set trust for {}: {e}", target.display()));
-        }
-
+        self.highlighted = TrustDirectorySelection::Trust;
+        self.error = None;
         self.selection = Some(TrustDirectorySelection::Trust);
     }
 
@@ -197,13 +190,10 @@ mod tests {
     use pretty_assertions::assert_eq;
     use ratatui::Terminal;
     use std::path::PathBuf;
-    use tempfile::TempDir;
 
     #[test]
     fn release_event_does_not_change_selection() {
-        let codex_home = TempDir::new().expect("temp home");
         let mut widget = TrustDirectoryWidget {
-            codex_home: codex_home.path().to_path_buf(),
             cwd: PathBuf::from("."),
             trust_target: PathBuf::from("."),
             show_windows_create_sandbox_hint: false,
@@ -227,9 +217,7 @@ mod tests {
 
     #[test]
     fn renders_snapshot_for_git_repo() {
-        let codex_home = TempDir::new().expect("temp home");
         let widget = TrustDirectoryWidget {
-            codex_home: codex_home.path().to_path_buf(),
             cwd: PathBuf::from("/workspace/project"),
             trust_target: PathBuf::from("/workspace/project"),
             show_windows_create_sandbox_hint: false,

--- a/codex-rs/tui/src/oss_selection.rs
+++ b/codex-rs/tui/src/oss_selection.rs
@@ -4,7 +4,6 @@ use std::sync::LazyLock;
 use crate::key_hint;
 use crate::key_hint::KeyBinding;
 use crate::key_hint::KeyBindingListExt;
-use crate::legacy_core::config::set_default_oss_provider;
 use codex_model_provider_info::DEFAULT_LMSTUDIO_PORT;
 use codex_model_provider_info::DEFAULT_OLLAMA_PORT;
 use codex_model_provider_info::LMSTUDIO_OSS_PROVIDER_ID;
@@ -309,7 +308,12 @@ fn get_status_symbol_and_color(status: &ProviderStatus) -> (&'static str, Color)
     }
 }
 
-pub async fn select_oss_provider(codex_home: &std::path::Path) -> io::Result<String> {
+pub(crate) struct OssProviderSelection {
+    pub(crate) provider: String,
+    pub(crate) manually_selected: bool,
+}
+
+pub async fn select_oss_provider() -> io::Result<OssProviderSelection> {
     // Check provider statuses first
     let lmstudio_status = check_lmstudio_status().await;
     let ollama_status = check_ollama_status().await;
@@ -318,11 +322,17 @@ pub async fn select_oss_provider(codex_home: &std::path::Path) -> io::Result<Str
     match (&lmstudio_status, &ollama_status) {
         (ProviderStatus::Running, ProviderStatus::NotRunning) => {
             let provider = LMSTUDIO_OSS_PROVIDER_ID.to_string();
-            return Ok(provider);
+            return Ok(OssProviderSelection {
+                provider,
+                manually_selected: false,
+            });
         }
         (ProviderStatus::NotRunning, ProviderStatus::Running) => {
             let provider = OLLAMA_OSS_PROVIDER_ID.to_string();
-            return Ok(provider);
+            return Ok(OssProviderSelection {
+                provider,
+                manually_selected: false,
+            });
         }
         _ => {
             // Both running or both not running - show UI
@@ -346,20 +356,15 @@ pub async fn select_oss_provider(codex_home: &std::path::Path) -> io::Result<Str
         if let Event::Key(key_event) = event::read()?
             && let Some(selection) = widget.handle_key_event(key_event)
         {
-            break Ok(selection);
+            break Ok(OssProviderSelection {
+                provider: selection,
+                manually_selected: true,
+            });
         }
     };
 
     disable_raw_mode()?;
     execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
-
-    // If the user manually selected an OSS provider, we save it as the
-    // default one to use later.
-    if let Ok(ref provider) = result
-        && let Err(e) = set_default_oss_provider(codex_home, provider)
-    {
-        tracing::warn!("Failed to save OSS provider preference: {e}");
-    }
 
     result
 }

--- a/codex-rs/tui/src/snapshots/codex_tui__markdown_render__markdown_render_tests__markdown_render_complex_snapshot.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__markdown_render__markdown_render_tests__markdown_render_complex_snapshot.snap
@@ -16,6 +16,7 @@ Image: alt text
 
 - Unordered list item 1
     - Nested bullet with italics inner
+
 - Unordered list item 2 with strikethrough
 
 1. Ordered item one

--- a/codex-rs/tui/src/snapshots/codex_tui__markdown_render__markdown_render_tests__multiline_finding_items_are_separated_snapshot.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__markdown_render__markdown_render_tests__multiline_finding_items_are_separated_snapshot.snap
@@ -1,0 +1,17 @@
+---
+source: tui/src/markdown_render_tests.rs
+expression: "plain_lines(&text).join(\"\\n\")"
+---
+Findings
+
+1. Correctness issue: server tool-search completions are always rejected.
+
+   In next_prompt_suggestion.rs, the output is ignored, suppressing suggestions after completed searches.
+
+   Minimal correction: count matching outputs and suppress only missing ones.
+
+2. High-confidence simplification: remove the unused error channel.
+
+   The implementation resolves failures to None, so its contract can be narrower.
+
+3. High-confidence churn reduction: consolidate table-driven filter tests.

--- a/codex-rs/tui/src/snapshots/codex_tui__markdown_render__markdown_render_tests__table_wraps_file_paths_before_collapsing_narrative_columns_snapshot.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__markdown_render__markdown_render_tests__table_wraps_file_paths_before_collapsing_narrative_columns_snapshot.snap
@@ -1,0 +1,26 @@
+---
+source: tui/src/markdown_render_tests.rs
+expression: "plain_lines(&text).join(\"\\n\")"
+---
+┌────────────────────────────────────────┬──────────────────┬──────┬─────────┬─────────────────────────────────────────┐
+│ Unit                                   │            Files │ Adds │ Removes │ What It Adds                            │
+├────────────────────────────────────────┼──────────────────┼──────┼─────────┼─────────────────────────────────────────┤
+│ Suggestion engine and unit coverage    │   codex-rs/core/ │  704 │       0 │ Sampling workflow, stable-history       │
+│                                        │             src/ │      │         │ checks, tool-flow suppression, fast     │
+│                                        │ next_prompt_sugg │      │         │ reasoning profile, filtering rules,     │
+│                                        │     estion.rs:1, │      │         │ cancellation and timeout.               │
+│                                        │   codex-rs/core/ │      │         │                                         │
+│                                        │             src/ │      │         │                                         │
+│                                        │ next_prompt_sugg │      │         │                                         │
+│                                        │ estion_tests.rs: │      │         │                                         │
+│                                        │                1 │      │         │                                         │
+│ Model instruction fragment and         │   codex-rs/core/ │   54 │       0 │ Synthetic suggestion prompt and an      │
+│ contextual isolation                   │     src/context/ │      │         │ isolation test for ordinary user text.  │
+│                                        │ next_prompt_sugg │      │         │                                         │
+│                                        │     estion.rs:1, │      │         │                                         │
+│                                        │   codex-rs/core/ │      │         │                                         │
+│                                        │     src/context/ │      │         │                                         │
+│                                        │ contextual_user_ │      │         │                                         │
+│                                        │ message_tests.rs │      │         │                                         │
+│                                        │               :1 │      │         │                                         │
+└────────────────────────────────────────┴──────────────────┴──────┴─────────┴─────────────────────────────────────────┘

--- a/codex-rs/tui/src/startup_hooks_review.rs
+++ b/codex-rs/tui/src/startup_hooks_review.rs
@@ -46,6 +46,7 @@ pub(crate) async fn maybe_run_startup_hooks_review(
     app_server: &mut AppServerSession,
     tui: &mut Tui,
     config: &Config,
+    bypass_hook_trust: bool,
 ) -> Result<StartupHooksReviewOutcome> {
     let cwd = config.cwd.to_path_buf();
     let response = match fetch_hooks_list(app_server.request_handle(), cwd.clone()).await {
@@ -56,7 +57,7 @@ pub(crate) async fn maybe_run_startup_hooks_review(
         }
     };
     let entry = hooks_list_entry_for_cwd(response, &cwd);
-    if review_needed_count(&entry) == 0 {
+    if !review_is_needed(bypass_hook_trust, &entry) {
         return Ok(StartupHooksReviewOutcome::Continue);
     }
 
@@ -223,6 +224,10 @@ fn review_needed_count(entry: &HooksListEntry) -> usize {
         .count()
 }
 
+fn review_is_needed(bypass_hook_trust: bool, entry: &HooksListEntry) -> bool {
+    !bypass_hook_trust && review_needed_count(entry) > 0
+}
+
 fn selection_item(name: &str, is_disabled: bool) -> SelectionItem {
     SelectionItem {
         name: name.to_string(),
@@ -259,6 +264,7 @@ impl WidgetRef for &StandaloneSelectionView<'_> {
 
 #[cfg(test)]
 mod tests {
+    use super::review_is_needed;
     use super::selection_view;
     use crate::app_event::AppEvent;
     use crate::app_event_sender::AppEventSender;
@@ -331,6 +337,16 @@ mod tests {
             })
             .collect::<Vec<_>>()
             .join("\n")
+    }
+
+    #[test]
+    fn bypass_hook_trust_suppresses_startup_review() {
+        assert!(!review_is_needed(/*bypass_hook_trust*/ true, &entry()));
+    }
+
+    #[test]
+    fn untrusted_hooks_need_review_without_bypass() {
+        assert!(review_is_needed(/*bypass_hook_trust*/ false, &entry()));
     }
 
     #[test]

--- a/codex-rs/tui/src/status/card.rs
+++ b/codex-rs/tui/src/status/card.rs
@@ -45,8 +45,10 @@ use super::rate_limits::compose_rate_limit_data;
 use super::rate_limits::compose_rate_limit_data_many;
 use super::rate_limits::format_status_limit_summary;
 use super::rate_limits::render_status_limit_progress_bar;
+use super::remote_connection::RemoteConnectionStatus;
 use crate::wrapping::RtOptions;
 use crate::wrapping::adaptive_wrap_lines;
+use crate::wrapping::word_wrap_lines;
 use std::sync::Arc;
 use std::sync::RwLock;
 
@@ -106,6 +108,7 @@ struct StatusHistoryCell {
     agents_summary: Arc<RwLock<String>>,
     collaboration_mode: Option<String>,
     model_provider: Option<String>,
+    remote_connection: Option<RemoteConnectionStatus>,
     show_chatgpt_usage_link: bool,
     account: Option<StatusAccountDisplay>,
     thread_name: Option<String>,
@@ -172,6 +175,7 @@ pub(crate) fn new_status_output_with_rate_limits(
     new_status_output_with_rate_limits_handle(
         config,
         /*runtime_model_provider_base_url*/ None,
+        /*remote_connection*/ None,
         account_display,
         token_info,
         total_usage,
@@ -194,6 +198,7 @@ pub(crate) fn new_status_output_with_rate_limits(
 pub(crate) fn new_status_output_with_rate_limits_handle(
     config: &Config,
     runtime_model_provider_base_url: Option<&str>,
+    remote_connection: Option<&RemoteConnectionStatus>,
     account_display: Option<&StatusAccountDisplay>,
     token_info: Option<&TokenUsageInfo>,
     total_usage: &TokenUsage,
@@ -213,6 +218,7 @@ pub(crate) fn new_status_output_with_rate_limits_handle(
     let (card, handle) = StatusHistoryCell::new(
         config,
         runtime_model_provider_base_url,
+        remote_connection,
         account_display,
         token_info,
         total_usage,
@@ -240,6 +246,7 @@ impl StatusHistoryCell {
     fn new(
         config: &Config,
         runtime_model_provider_base_url: Option<&str>,
+        remote_connection: Option<&RemoteConnectionStatus>,
         account_display: Option<&StatusAccountDisplay>,
         token_info: Option<&TokenUsageInfo>,
         total_usage: &TokenUsage,
@@ -349,6 +356,7 @@ impl StatusHistoryCell {
                 permissions,
                 collaboration_mode: collaboration_mode.map(ToString::to_string),
                 model_provider,
+                remote_connection: remote_connection.cloned(),
                 show_chatgpt_usage_link,
                 account,
                 thread_name,
@@ -689,7 +697,6 @@ impl HistoryCell for StatusHistoryCell {
             Span::from(" ").dim(),
             Span::from(format!("(v{CODEX_CLI_VERSION})")).dim(),
         ]));
-        lines.push(Line::from(Vec::<Span<'static>>::new()));
 
         let available_inner_width = usize::from(width.saturating_sub(4));
         if available_inner_width == 0 {
@@ -768,10 +775,28 @@ impl HistoryCell for StatusHistoryCell {
             [note_first_line, note_second_line],
             RtOptions::new(available_inner_width),
         );
+        lines.push(Line::from(Vec::<Span<'static>>::new()));
         // The ChatGPT usage page only applies to providers backed by OpenAI auth;
         // providers like Bedrock manage limits and billing elsewhere.
         if self.show_chatgpt_usage_link {
             lines.extend(note_lines);
+            lines.push(Line::from(Vec::<Span<'static>>::new()));
+        }
+        if let Some(remote_connection) = self.remote_connection.as_ref() {
+            let wrapped_remote = word_wrap_lines(
+                [Line::from(vec![
+                    Span::from(remote_connection.address.clone()),
+                    Span::from(" (").dim(),
+                    Span::from(remote_connection.version.clone()).dim(),
+                    Span::from(")").dim(),
+                ])],
+                RtOptions::new(value_width.max(1)),
+            );
+            let mut wrapped_remote = wrapped_remote.into_iter();
+            if let Some(first) = wrapped_remote.next() {
+                lines.push(formatter.line("Remote", first.spans));
+                lines.extend(wrapped_remote.map(|line| formatter.continuation(line.spans)));
+            }
             lines.push(Line::from(Vec::<Span<'static>>::new()));
         }
 

--- a/codex-rs/tui/src/status/mod.rs
+++ b/codex-rs/tui/src/status/mod.rs
@@ -11,6 +11,7 @@ mod card;
 mod format;
 mod helpers;
 mod rate_limits;
+pub(crate) mod remote_connection;
 
 pub(crate) use account::StatusAccountDisplay;
 pub(crate) use card::StatusHistoryHandle;

--- a/codex-rs/tui/src/status/remote_connection.rs
+++ b/codex-rs/tui/src/status/remote_connection.rs
@@ -1,0 +1,86 @@
+use crate::AppServerTarget;
+use crate::RemoteAppServerEndpoint;
+use url::Url;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct RemoteConnectionStatus {
+    pub(crate) address: String,
+    pub(crate) version: String,
+}
+
+pub(crate) fn remote_connection_status_value(
+    app_server_target: &AppServerTarget,
+    server_version: Option<&str>,
+) -> Option<RemoteConnectionStatus> {
+    let endpoint = match app_server_target {
+        AppServerTarget::Embedded => return None,
+        AppServerTarget::LocalDaemon { endpoint } | AppServerTarget::Remote { endpoint } => {
+            endpoint
+        }
+    };
+    let address = match endpoint {
+        RemoteAppServerEndpoint::WebSocket { websocket_url, .. } => {
+            sanitized_websocket_display_address(websocket_url)
+                .unwrap_or_else(|| "<invalid websocket URL>".to_string())
+        }
+        RemoteAppServerEndpoint::UnixSocket { socket_path } => {
+            format!("unix://{}", socket_path.display())
+        }
+    };
+    let version = server_version
+        .map(|version| format!("v{version}"))
+        .unwrap_or_else(|| "unknown".to_string());
+    Some(RemoteConnectionStatus { address, version })
+}
+
+fn sanitized_websocket_display_address(raw: &str) -> Option<String> {
+    let mut url = Url::parse(raw).ok()?;
+    let _ = url.set_username("");
+    let _ = url.set_password(None);
+    url.set_query(None);
+    url.set_fragment(None);
+    Some(url.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use codex_utils_absolute_path::AbsolutePathBuf;
+
+    #[test]
+    fn remote_connection_status_value_formats_display_value() -> color_eyre::Result<()> {
+        assert_eq!(
+            remote_connection_status_value(&AppServerTarget::Embedded, Some("1.2.3")),
+            None
+        );
+
+        let websocket_target = AppServerTarget::Remote {
+            endpoint: RemoteAppServerEndpoint::WebSocket {
+                websocket_url: "ws://user:secret@127.0.0.1:4500/?token=abc#frag".to_string(),
+                auth_token: Some("abc".to_string()),
+            },
+        };
+        assert_eq!(
+            remote_connection_status_value(&websocket_target, Some("1.2.3")),
+            Some(RemoteConnectionStatus {
+                address: "ws://127.0.0.1:4500/".to_string(),
+                version: "v1.2.3".to_string(),
+            })
+        );
+
+        let socket_path = AbsolutePathBuf::relative_to_current_dir("codex.sock")?;
+        let daemon_target = AppServerTarget::LocalDaemon {
+            endpoint: RemoteAppServerEndpoint::UnixSocket {
+                socket_path: socket_path.clone(),
+            },
+        };
+        assert_eq!(
+            remote_connection_status_value(&daemon_target, /*server_version*/ None),
+            Some(RemoteConnectionStatus {
+                address: format!("unix://{}", socket_path.display()),
+                version: "unknown".to_string(),
+            })
+        );
+        Ok(())
+    }
+}

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_uses_default_reasoning_when_config_empty.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_uses_default_reasoning_when_config_empty.snap
@@ -4,18 +4,21 @@ expression: sanitized
 ---
 /status
 
-╭─────────────────────────────────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.0)                                               │
-│                                                                         │
-│ Visit https://chatgpt.com/codex/settings/usage for up-to-date           │
-│ information on rate limits and credits                                  │
-│                                                                         │
-│  Model:            gpt-5.1-codex-max (reasoning medium, summaries auto) │
-│  Directory: [[workspace]]                                               │
-│  Permissions:      Custom (workspace with network access, on-request)   │
-│  Agents.md:        <none>                                               │
-│                                                                         │
-│  Token usage:      750 total  (500 input + 250 output)                  │
-│  Context window:   100% left (750 used / 272K)                          │
-│  Limits:           data not available yet                               │
-╰─────────────────────────────────────────────────────────────────────────╯
+╭──────────────────────────────────────────────────────────────────────────╮
+│  >_ OpenAI Codex (v0.0.0)                                                │
+│                                                                          │
+│ Visit https://chatgpt.com/codex/settings/usage for up-to-date            │
+│ information on rate limits and credits                                   │
+│                                                                          │
+│  Remote:           unix:///tmp/codex-home/app-server-control/app-server- │
+│                    control.sock (v0.133.0)                               │
+│                                                                          │
+│  Model:            gpt-5.1-codex-max (reasoning medium, summaries auto)  │
+│  Directory: [[workspace]]                                                │
+│  Permissions:      Custom (workspace with network access, on-request)    │
+│  Agents.md:        <none>                                                │
+│                                                                          │
+│  Token usage:      750 total  (500 input + 250 output)                   │
+│  Context window:   100% left (750 used / 272K)                           │
+│  Limits:           data not available yet                                │
+╰──────────────────────────────────────────────────────────────────────────╯

--- a/codex-rs/tui/src/status/tests.rs
+++ b/codex-rs/tui/src/status/tests.rs
@@ -7,6 +7,7 @@ use crate::legacy_core::config::Config;
 use crate::legacy_core::config::ConfigBuilder;
 use crate::legacy_core::config::PermissionProfileSnapshot;
 use crate::status::StatusAccountDisplay;
+use crate::status::remote_connection::RemoteConnectionStatus;
 use crate::test_support::PathBufExt;
 use crate::test_support::test_path_buf;
 use crate::token_usage::TokenUsage;
@@ -604,6 +605,7 @@ async fn status_model_provider_uses_bedrock_runtime_base_url_and_gates_usage_lin
     let (composite, _handle) = new_status_output_with_rate_limits_handle(
         &config,
         Some(runtime_base_url),
+        /*remote_connection*/ None,
         test_status_account_display().as_ref(),
         /*token_info*/ None,
         &usage,
@@ -644,6 +646,7 @@ async fn status_model_provider_uses_bedrock_runtime_base_url_and_gates_usage_lin
     let (composite, _handle) = new_status_output_with_rate_limits_handle(
         &config,
         /*runtime_model_provider_base_url*/ None,
+        /*remote_connection*/ None,
         test_status_account_display().as_ref(),
         /*token_info*/ None,
         &usage,
@@ -1321,12 +1324,17 @@ async fn status_snapshot_uses_default_reasoning_when_config_empty() {
         .with_ymd_and_hms(2024, 2, 3, 4, 5, 6)
         .single()
         .expect("timestamp");
+    let remote_connection = RemoteConnectionStatus {
+        address: "unix:///tmp/codex-home/app-server-control/app-server-control.sock".to_string(),
+        version: "v0.133.0".to_string(),
+    };
 
     let model_slug = crate::legacy_core::test_support::get_model_offline(config.model.as_deref());
     let token_info = token_info_for(&model_slug, &config, &usage);
     let (composite, _) = new_status_output_with_rate_limits_handle(
         &config,
         /*runtime_model_provider_base_url*/ None,
+        Some(&remote_connection),
         account_display.as_ref(),
         Some(&token_info),
         &usage,

--- a/codex-rs/tui/src/streaming/controller.rs
+++ b/codex-rs/tui/src/streaming/controller.rs
@@ -1189,6 +1189,7 @@ mod tests {
             "3. Loose item with its own paragraph.".to_string(),
             "".to_string(),
             "   This paragraph belongs to the same list item.".to_string(),
+            "".to_string(),
             "4. Second loose item with a nested list after a blank line.".to_string(),
             "    - Nested bullet under a loose item".to_string(),
             "    - Another nested bullet".to_string(),

--- a/codex-rs/tui/src/tui.rs
+++ b/codex-rs/tui/src/tui.rs
@@ -56,6 +56,7 @@ mod frame_requester;
 #[cfg(unix)]
 mod job_control;
 mod keyboard_modes;
+mod terminal_stderr;
 
 /// Target frame interval for UI redraw scheduling.
 pub(crate) const TARGET_FRAME_INTERVAL: Duration = frame_rate_limiter::MIN_FRAME_INTERVAL;
@@ -66,6 +67,7 @@ pub type Terminal = CustomTerminal<CrosstermBackend<Stdout>>;
 pub(crate) struct InitializedTerminal {
     pub(crate) terminal: Terminal,
     pub(crate) enhanced_keys_supported: bool,
+    pub(crate) stderr_guard: terminal_stderr::TerminalStderrGuard,
 }
 
 pub(crate) fn running_in_vscode_terminal() -> bool {
@@ -281,7 +283,16 @@ pub fn restore() -> Result<()> {
 /// Uses a stronger keyboard reset than [`restore`] so the parent shell recovers even if a
 /// terminal missed the stack pop that normally pairs with [`set_modes`].
 pub fn restore_after_exit() -> Result<()> {
-    restore_common(RawModeRestore::Disable, KeyboardRestore::ResetAfterExit)
+    let mut first_error =
+        restore_common(RawModeRestore::Disable, KeyboardRestore::ResetAfterExit).err();
+    if let Err(err) = terminal_stderr::finish() {
+        first_error.get_or_insert(err);
+    }
+
+    match first_error {
+        Some(err) => Err(err),
+        None => Ok(()),
+    }
 }
 
 /// Restore the terminal to its original state, but keep raw mode enabled.
@@ -425,9 +436,11 @@ pub(crate) fn init() -> Result<InitializedTerminal> {
         !keyboard_modes::keyboard_enhancement_disabled() && detect_keyboard_enhancement_supported();
 
     let tui = CustomTerminal::with_options_and_cursor_position(backend, cursor_pos)?;
+    let stderr_guard = terminal_stderr::TerminalStderrGuard::install()?;
     Ok(InitializedTerminal {
         terminal: tui,
         enhanced_keys_supported,
+        stderr_guard,
     })
 }
 
@@ -489,6 +502,8 @@ pub struct Tui {
     notification_condition: NotificationCondition,
     // When false, enter_alt_screen() becomes a no-op.
     alt_screen_enabled: bool,
+    // Keeps unmanaged process stderr writes out of the inline viewport.
+    _stderr_guard: terminal_stderr::TerminalStderrGuard,
 }
 
 struct PendingHistoryLines {
@@ -509,7 +524,11 @@ where
 }
 
 impl Tui {
-    pub fn new(terminal: Terminal, enhanced_keys_supported: bool) -> Self {
+    pub(crate) fn new(
+        terminal: Terminal,
+        enhanced_keys_supported: bool,
+        stderr_guard: terminal_stderr::TerminalStderrGuard,
+    ) -> Self {
         let (draw_tx, _) = broadcast::channel(1);
         let frame_requester = FrameRequester::new(draw_tx.clone());
 
@@ -534,6 +553,7 @@ impl Tui {
             notification_backend: Some(detect_backend(NotificationMethod::default())),
             notification_condition: NotificationCondition::default(),
             alt_screen_enabled: true,
+            _stderr_guard: stderr_guard,
         }
     }
 
@@ -577,8 +597,8 @@ impl Tui {
     /// Temporarily restore terminal state to run an external interactive program `f`.
     ///
     /// This pauses crossterm's stdin polling by dropping the underlying event stream, restores
-    /// terminal modes (optionally keeping raw mode enabled), then re-applies Codex TUI modes and
-    /// flushes pending stdin input before resuming events.
+    /// terminal modes and stderr (optionally keeping raw mode enabled), then re-applies Codex TUI
+    /// modes and stderr suppression before resuming events.
     pub async fn with_restored<R, F, Fut>(&mut self, mode: RestoreMode, f: F) -> R
     where
         F: FnOnce() -> Fut,
@@ -596,9 +616,15 @@ impl Tui {
         if let Err(err) = mode.restore() {
             tracing::warn!("failed to restore terminal modes before external program: {err}");
         }
+        if let Err(err) = terminal_stderr::pause() {
+            tracing::warn!("failed to restore terminal stderr before external program: {err}");
+        }
 
         let output = f().await;
 
+        if let Err(err) = terminal_stderr::resume() {
+            tracing::warn!("failed to suppress terminal stderr after external program: {err}");
+        }
         if let Err(err) = set_modes() {
             tracing::warn!("failed to re-enable terminal modes after external program: {err}");
         }

--- a/codex-rs/tui/src/tui/job_control.rs
+++ b/codex-rs/tui/src/tui/job_control.rs
@@ -175,8 +175,12 @@ impl PreparedResumeAction {
 /// Deliver SIGTSTP after restoring terminal state, then re-applies terminal modes once resumed.
 fn suspend_process() -> Result<()> {
     super::restore()?;
-    unsafe { libc::kill(0, libc::SIGTSTP) };
+    super::terminal_stderr::pause()?;
+    unsafe {
+        libc::kill(/*pid*/ 0, libc::SIGTSTP)
+    };
     // After the process resumes, reapply terminal modes so drawing can continue.
+    super::terminal_stderr::resume()?;
     super::set_modes()?;
     Ok(())
 }

--- a/codex-rs/tui/src/tui/terminal_stderr.rs
+++ b/codex-rs/tui/src/tui/terminal_stderr.rs
@@ -1,0 +1,275 @@
+//! Protect the inline viewport from unmanaged macOS writes to stderr.
+//!
+//! Some macOS frameworks and runtime diagnostics write directly to file
+//! descriptor 2. While the inline TUI is active, those writes paint into the
+//! same terminal region as the composer without going through the renderer.
+//! Keep them off the terminal until the TUI releases terminal ownership.
+
+use std::io;
+
+#[cfg(target_os = "macos")]
+use std::fs::OpenOptions;
+#[cfg(target_os = "macos")]
+use std::io::IsTerminal;
+#[cfg(target_os = "macos")]
+use std::mem::MaybeUninit;
+#[cfg(target_os = "macos")]
+use std::os::fd::AsRawFd;
+#[cfg(target_os = "macos")]
+use std::os::fd::FromRawFd;
+#[cfg(target_os = "macos")]
+use std::os::fd::OwnedFd;
+#[cfg(target_os = "macos")]
+use std::sync::Mutex;
+#[cfg(target_os = "macos")]
+use std::sync::MutexGuard;
+
+#[cfg(target_os = "macos")]
+static STDERR_STATE: Mutex<StderrState> = Mutex::new(StderrState {
+    owner_active: false,
+    saved_stderr: None,
+});
+
+#[cfg(target_os = "macos")]
+struct StderrState {
+    owner_active: bool,
+    saved_stderr: Option<OwnedFd>,
+}
+
+/// Keeps unmanaged stderr output away from the terminal while the TUI owns it.
+pub(crate) struct TerminalStderrGuard {
+    active: bool,
+}
+
+impl TerminalStderrGuard {
+    pub(super) fn install() -> io::Result<Self> {
+        #[cfg(target_os = "macos")]
+        {
+            if stderr_targets_stdout_terminal() {
+                return Self::install_suppression();
+            }
+        }
+
+        Ok(Self { active: false })
+    }
+
+    #[cfg(target_os = "macos")]
+    fn install_suppression() -> io::Result<Self> {
+        let mut state = lock_state()?;
+        if state.owner_active {
+            return Err(io::Error::new(
+                io::ErrorKind::AlreadyExists,
+                "terminal stderr suppression is already active",
+            ));
+        }
+        suppress_locked(&mut state)?;
+        state.owner_active = true;
+        Ok(Self { active: true })
+    }
+}
+
+impl Drop for TerminalStderrGuard {
+    fn drop(&mut self) {
+        if self.active {
+            let _ = finish();
+            self.active = false;
+        }
+    }
+}
+
+/// Restores stderr while terminal ownership is temporarily released.
+pub(super) fn pause() -> io::Result<()> {
+    #[cfg(target_os = "macos")]
+    {
+        let mut state = lock_state()?;
+        if state.owner_active {
+            restore_locked(&mut state)?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Suppresses stderr again when terminal ownership returns to the TUI.
+pub(super) fn resume() -> io::Result<()> {
+    #[cfg(target_os = "macos")]
+    {
+        let mut state = lock_state()?;
+        if state.owner_active {
+            suppress_locked(&mut state)?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Restores stderr permanently when the TUI session ends.
+pub(super) fn finish() -> io::Result<()> {
+    #[cfg(target_os = "macos")]
+    {
+        let mut state = lock_state()?;
+        if state.owner_active {
+            restore_locked(&mut state)?;
+            state.owner_active = false;
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn lock_state() -> io::Result<MutexGuard<'static, StderrState>> {
+    STDERR_STATE
+        .lock()
+        .map_err(|_| io::Error::other("terminal stderr suppression lock poisoned"))
+}
+
+#[cfg(target_os = "macos")]
+fn stderr_targets_stdout_terminal() -> bool {
+    if !io::stdout().is_terminal() || !io::stderr().is_terminal() {
+        return false;
+    }
+
+    let mut stdout_stat = MaybeUninit::<libc::stat>::uninit();
+    let mut stderr_stat = MaybeUninit::<libc::stat>::uninit();
+    // SAFETY: both output pointers reference valid storage for libc to initialize.
+    if unsafe {
+        libc::fstat(libc::STDOUT_FILENO, stdout_stat.as_mut_ptr()) != 0
+            || libc::fstat(libc::STDERR_FILENO, stderr_stat.as_mut_ptr()) != 0
+    } {
+        return false;
+    }
+    // SAFETY: both fstat calls above returned successfully.
+    let (stdout_stat, stderr_stat) =
+        unsafe { (stdout_stat.assume_init(), stderr_stat.assume_init()) };
+    stdout_stat.st_dev == stderr_stat.st_dev && stdout_stat.st_ino == stderr_stat.st_ino
+}
+
+#[cfg(target_os = "macos")]
+fn suppress_locked(state: &mut StderrState) -> io::Result<()> {
+    if state.saved_stderr.is_some() {
+        return Ok(());
+    }
+
+    // SAFETY: dup returns a newly owned file descriptor on success.
+    let saved_stderr = unsafe { libc::dup(libc::STDERR_FILENO) };
+    if saved_stderr == -1 {
+        return Err(io::Error::last_os_error());
+    }
+    // SAFETY: saved_stderr is a fresh descriptor returned by dup above.
+    let saved_stderr = unsafe { OwnedFd::from_raw_fd(saved_stderr) };
+    let devnull = OpenOptions::new().write(true).open("/dev/null")?;
+    // SAFETY: both descriptors are valid for the duration of this call.
+    if unsafe { libc::dup2(devnull.as_raw_fd(), libc::STDERR_FILENO) } == -1 {
+        return Err(io::Error::last_os_error());
+    }
+    state.saved_stderr = Some(saved_stderr);
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn restore_locked(state: &mut StderrState) -> io::Result<()> {
+    let Some(saved_stderr) = state.saved_stderr.as_ref() else {
+        return Ok(());
+    };
+
+    // SAFETY: saved_stderr was duplicated from stderr and remains owned here.
+    if unsafe { libc::dup2(saved_stderr.as_raw_fd(), libc::STDERR_FILENO) } == -1 {
+        return Err(io::Error::last_os_error());
+    }
+    state.saved_stderr = None;
+    Ok(())
+}
+
+#[cfg(all(test, target_os = "macos"))]
+mod tests {
+    use std::fs::File;
+    use std::io::Read;
+    use std::io::Seek;
+    use std::io::Write;
+    use std::os::fd::AsRawFd;
+    use std::os::fd::FromRawFd;
+    use std::os::fd::OwnedFd;
+
+    use pretty_assertions::assert_eq;
+    use serial_test::serial;
+
+    use super::TerminalStderrGuard;
+    use super::finish;
+    use super::pause;
+    use super::resume;
+
+    struct CapturedStderr {
+        saved_stderr: OwnedFd,
+    }
+
+    impl CapturedStderr {
+        fn start(file: &File) -> std::io::Result<Self> {
+            // SAFETY: dup returns a newly owned file descriptor on success.
+            let saved_stderr = unsafe { libc::dup(libc::STDERR_FILENO) };
+            if saved_stderr == -1 {
+                return Err(std::io::Error::last_os_error());
+            }
+            // SAFETY: saved_stderr is a fresh descriptor returned by dup above.
+            let saved_stderr = unsafe { OwnedFd::from_raw_fd(saved_stderr) };
+            // SAFETY: both descriptors are valid for the duration of this call.
+            if unsafe { libc::dup2(file.as_raw_fd(), libc::STDERR_FILENO) } == -1 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(Self { saved_stderr })
+        }
+    }
+
+    impl Drop for CapturedStderr {
+        fn drop(&mut self) {
+            // SAFETY: saved_stderr remains owned for the duration of this call.
+            let _ = unsafe { libc::dup2(self.saved_stderr.as_raw_fd(), libc::STDERR_FILENO) };
+        }
+    }
+
+    fn write_stderr(message: &str) -> std::io::Result<()> {
+        let mut stderr = std::io::stderr().lock();
+        stderr.write_all(message.as_bytes())?;
+        stderr.flush()
+    }
+
+    #[test]
+    #[serial]
+    fn suppresses_stderr_only_while_terminal_is_owned() -> std::io::Result<()> {
+        let mut output = tempfile::tempfile()?;
+        let capture = CapturedStderr::start(&output)?;
+
+        let _guard = TerminalStderrGuard::install_suppression()?;
+        write_stderr("hidden while active\n")?;
+        pause()?;
+        write_stderr("visible while paused\n")?;
+        resume()?;
+        write_stderr("hidden after resume\n")?;
+        finish()?;
+        write_stderr("visible after finish\n")?;
+
+        drop(capture);
+        output.rewind()?;
+        let mut captured = String::new();
+        output.read_to_string(&mut captured)?;
+        assert_eq!(captured, "visible while paused\nvisible after finish\n");
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn preserves_stderr_when_already_redirected() -> std::io::Result<()> {
+        let mut output = tempfile::tempfile()?;
+        let capture = CapturedStderr::start(&output)?;
+
+        let _guard = TerminalStderrGuard::install()?;
+        write_stderr("visible while redirected\n")?;
+
+        drop(capture);
+        output.rewind()?;
+        let mut captured = String::new();
+        output.read_to_string(&mut captured)?;
+        assert_eq!(captured, "visible while redirected\n");
+        Ok(())
+    }
+}


### PR DESCRIPTION
Daily upstream sync. Merges openai/codex upstream/main into feat/claude-compat with a normal merge commit.

Verification:
- cargo check --workspace --offline
- cargo test --offline -p codex-core-skills -p codex-hooks
- cargo test --offline -p codex-cli --test version
- just fmt (cargo fmt completed; uv/ruff failed on unavailable openai-codex-cli-bin Linux wheel)
- cargo build --offline --release -p codex-cli --bin codex

Conflict-resolution log: none; merge completed without conflicts.