### PR TITLE
sync: merge upstream/main into feat/claude-compat (2026-06-21)

### DIFF
--- a/codex-rs/app-server-protocol/src/protocol/thread_history.rs
+++ b/codex-rs/app-server-protocol/src/protocol/thread_history.rs
@@ -3341,6 +3341,8 @@ mod tests {
                 message: String::new(),
                 replacement_history: None,
                 window_number: None,
+                first_window_id: None,
+                previous_window_id: None,
                 window_id: None,
             }),
             RolloutItem::EventMsg(EventMsg::TurnComplete(TurnCompleteEvent {

--- a/codex-rs/config/src/schema.rs
+++ b/codex-rs/config/src/schema.rs
@@ -44,6 +44,15 @@ pub fn features_schema(schema_gen: &mut SchemaGenerator) -> Schema {
             );
             continue;
         }
+        if feature.id == codex_features::Feature::TokenBudget {
+            validation.properties.insert(
+                feature.key.to_string(),
+                schema_gen.subschema_for::<codex_features::FeatureToml<
+                    codex_features::TokenBudgetConfigToml,
+                >>(),
+            );
+            continue;
+        }
         if feature.id == codex_features::Feature::RolloutBudget {
             validation.properties.insert(
                 feature.key.to_string(),

--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -669,7 +669,7 @@
               "type": "boolean"
             },
             "token_budget": {
-              "type": "boolean"
+              "$ref": "#/definitions/FeatureToml_for_TokenBudgetConfigToml"
             },
             "tool_call_mcp_elicitation": {
               "type": "boolean"
@@ -964,6 +964,16 @@
         },
         {
           "$ref": "#/definitions/RolloutBudgetConfigToml"
+        }
+      ]
+    },
+    "FeatureToml_for_TokenBudgetConfigToml": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/definitions/TokenBudgetConfigToml"
         }
       ]
     },
@@ -2835,6 +2845,27 @@
           "type": "object"
         }
       ]
+    },
+    "TokenBudgetConfigToml": {
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "reminder_message_template": {
+          "description": "Reminder template. `{n_remaining}` is replaced with the tokens remaining before auto-compaction.",
+          "maxLength": 1000,
+          "minLength": 1,
+          "type": "string"
+        },
+        "reminder_threshold_tokens": {
+          "description": "Number of tokens remaining before auto-compaction when the wrap-up reminder is emitted.",
+          "format": "int64",
+          "minimum": 1.0,
+          "type": "integer"
+        }
+      },
+      "type": "object"
     },
     "ToolSuggestConfig": {
       "additionalProperties": false,
@@ -4932,7 +4963,7 @@
           "type": "boolean"
         },
         "token_budget": {
-          "type": "boolean"
+          "$ref": "#/definitions/FeatureToml_for_TokenBudgetConfigToml"
         },
         "tool_call_mcp_elicitation": {
           "type": "boolean"

--- a/codex-rs/core/src/agent/control_tests.rs
+++ b/codex-rs/core/src/agent/control_tests.rs
@@ -1160,6 +1160,8 @@ async fn spawn_agent_fork_strips_parent_usage_hints_from_compacted_history() {
                 message: String::new(),
                 replacement_history: Some(replacement_history),
                 window_number: None,
+                first_window_id: None,
+                previous_window_id: None,
                 window_id: None,
             }),
             RolloutItem::TurnContext(turn_context.to_turn_context_item()),

--- a/codex-rs/core/src/compact.rs
+++ b/codex-rs/core/src/compact.rs
@@ -302,7 +302,7 @@ async fn run_compact_task_inner_impl(
     let user_messages = collect_user_messages(history_items);
 
     let mut new_history = build_compacted_history(Vec::new(), &user_messages, &summary_text);
-    let (window_number, window_id) = sess.advance_auto_compact_window().await;
+    let (window_number, window_ids) = sess.advance_auto_compact_window().await;
 
     if matches!(
         initial_context_injection,
@@ -320,7 +320,9 @@ async fn run_compact_task_inner_impl(
         message: summary_text.clone(),
         replacement_history: Some(new_history.clone()),
         window_number: Some(window_number),
-        window_id: Some(window_id),
+        first_window_id: Some(window_ids.first_window_id.to_string()),
+        previous_window_id: window_ids.previous_window_id.map(|id| id.to_string()),
+        window_id: Some(window_ids.window_id.to_string()),
     };
     sess.replace_compacted_history(
         turn_context.as_ref(),

--- a/codex-rs/core/src/compact_remote.rs
+++ b/codex-rs/core/src/compact_remote.rs
@@ -258,7 +258,7 @@ async fn run_remote_compact_task_inner_impl(
             &responses_metadata,
         )
         .await?;
-    let (new_window_number, new_window_id) = sess.advance_auto_compact_window().await;
+    let (new_window_number, new_window_ids) = sess.advance_auto_compact_window().await;
     new_history = process_compacted_history(
         sess.as_ref(),
         turn_context.as_ref(),
@@ -275,7 +275,9 @@ async fn run_remote_compact_task_inner_impl(
         message: String::new(),
         replacement_history: Some(new_history.clone()),
         window_number: Some(new_window_number),
-        window_id: Some(new_window_id),
+        first_window_id: Some(new_window_ids.first_window_id.to_string()),
+        previous_window_id: new_window_ids.previous_window_id.map(|id| id.to_string()),
+        window_id: Some(new_window_ids.window_id.to_string()),
     };
     // Install is the semantic boundary where the compact endpoint's output becomes live
     // thread history. Keep it distinct from the later inference request so the reducer can

--- a/codex-rs/core/src/compact_remote_v2.rs
+++ b/codex-rs/core/src/compact_remote_v2.rs
@@ -292,7 +292,7 @@ async fn run_remote_compact_task_inner_impl(
     let (compacted_history, retained_images) =
         build_v2_compacted_history(&prompt_input, compaction_output);
     analytics_details.retained_image_count = Some(retained_images);
-    let (new_window_number, new_window_id) = sess.advance_auto_compact_window().await;
+    let (new_window_number, new_window_ids) = sess.advance_auto_compact_window().await;
     let new_history = process_compacted_history(
         sess.as_ref(),
         turn_context.as_ref(),
@@ -309,7 +309,9 @@ async fn run_remote_compact_task_inner_impl(
         message: String::new(),
         replacement_history: Some(new_history.clone()),
         window_number: Some(new_window_number),
-        window_id: Some(new_window_id),
+        first_window_id: Some(new_window_ids.first_window_id.to_string()),
+        previous_window_id: new_window_ids.previous_window_id.map(|id| id.to_string()),
+        window_id: Some(new_window_ids.window_id.to_string()),
     };
     compaction_trace.record_installed(&CompactionCheckpointTracePayload {
         input_history: &trace_input_history,

--- a/codex-rs/core/src/config/config_tests.rs
+++ b/codex-rs/core/src/config/config_tests.rs
@@ -461,6 +461,90 @@ direct_only_tool_namespaces = ["mcp__history", "mcp__notes"]
 }
 
 #[tokio::test]
+async fn load_config_resolves_token_budget_config() -> std::io::Result<()> {
+    for (config_toml, expected) in [
+        (
+            "[features]\ntoken_budget = true\n",
+            TokenBudgetConfig::default(),
+        ),
+        (
+            r#"
+[features.token_budget]
+enabled = true
+reminder_threshold_tokens = 16000
+reminder_message_template = "Custom reminder: {n_remaining} tokens."
+"#,
+            TokenBudgetConfig {
+                reminder_threshold_tokens: Some(16_000),
+                reminder_message_template: "Custom reminder: {n_remaining} tokens.".to_string(),
+            },
+        ),
+    ] {
+        let codex_home = tempdir()?;
+        let config_toml = toml::from_str(config_toml).expect("TOML should deserialize");
+        let config = Config::load_from_base_config_with_overrides(
+            config_toml,
+            ConfigOverrides::default(),
+            codex_home.abs(),
+        )
+        .await?;
+
+        assert!(config.features.enabled(Feature::TokenBudget));
+        assert_eq!(config.token_budget, Some(expected));
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn load_config_rejects_invalid_token_budget_reminder_template() -> std::io::Result<()> {
+    for reminder_message_template in [
+        String::new(),
+        "x".repeat(TOKEN_BUDGET_REMINDER_MESSAGE_TEMPLATE_MAX_BYTES + 1),
+    ] {
+        let codex_home = tempdir()?;
+        let config_toml = toml::from_str(&format!(
+            "[features.token_budget]\nenabled = true\nreminder_message_template = {reminder_message_template:?}\n"
+        ))
+        .expect("TOML should deserialize");
+        let error = Config::load_from_base_config_with_overrides(
+            config_toml,
+            ConfigOverrides::default(),
+            codex_home.abs(),
+        )
+        .await
+        .expect_err("invalid reminder template should be rejected");
+
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn load_config_rejects_non_positive_token_budget_reminder_threshold() -> std::io::Result<()> {
+    for reminder_threshold_tokens in [-1, 0] {
+        let codex_home = tempdir()?;
+        let config_toml = toml::from_str(&format!(
+            "[features.token_budget]\nenabled = true\nreminder_threshold_tokens = {reminder_threshold_tokens}\n"
+        ))
+        .expect("TOML should deserialize");
+        let error = Config::load_from_base_config_with_overrides(
+            config_toml,
+            ConfigOverrides::default(),
+            codex_home.abs(),
+        )
+        .await
+        .expect_err("non-positive reminder threshold should be rejected");
+
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
+        assert_eq!(
+            error.to_string(),
+            "features.token_budget.reminder_threshold_tokens must be positive"
+        );
+    }
+    Ok(())
+}
+
+#[tokio::test]
 async fn load_config_resolves_rollout_budget() -> std::io::Result<()> {
     let codex_home = tempdir()?;
     let config_toml: ConfigToml = toml::from_str(

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -68,6 +68,7 @@ use codex_features::Features;
 use codex_features::FeaturesToml;
 use codex_features::MultiAgentV2ConfigToml;
 use codex_features::NetworkProxyConfigToml;
+use codex_features::TokenBudgetConfigToml;
 use codex_git_utils::resolve_root_git_project_for_trust;
 use codex_install_context::InstallContext;
 use codex_login::AuthManagerConfig;
@@ -1026,6 +1027,8 @@ pub struct Config {
     /// Settings specific to the task-path-based multi-agent tool surface.
     pub multi_agent_v2: MultiAgentV2Config,
 
+    /// Context-window token budget configuration, when enabled.
+    pub token_budget: Option<TokenBudgetConfig>,
     /// Shared token budget for the root thread and its sub-agents.
     pub rollout_budget: Option<RolloutBudgetConfig>,
     /// Current-time reminder configuration, when enabled.
@@ -1073,6 +1076,27 @@ pub struct Config {
 pub struct CodeModeConfig {
     pub excluded_tool_namespaces: Vec<String>,
     pub direct_only_tool_namespaces: Vec<String>,
+}
+
+pub(crate) const DEFAULT_TOKEN_BUDGET_REMINDER_MESSAGE_TEMPLATE: &str = concat!(
+    "Your context window is nearly exhausted (only {n_remaining} tokens remaining) and will be automatically reset for you soon. ",
+    "Once reset, message items in current context window will be cleared in the new window, but notes and history items will be persistent across windows."
+);
+const TOKEN_BUDGET_REMINDER_MESSAGE_TEMPLATE_MAX_BYTES: usize = 1000;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct TokenBudgetConfig {
+    pub reminder_threshold_tokens: Option<i64>,
+    pub reminder_message_template: String,
+}
+
+impl Default for TokenBudgetConfig {
+    fn default() -> Self {
+        Self {
+            reminder_threshold_tokens: None,
+            reminder_message_template: DEFAULT_TOKEN_BUDGET_REMINDER_MESSAGE_TEMPLATE.to_string(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Serialize)]
@@ -2509,6 +2533,48 @@ fn resolve_multi_agent_v2_config(config_toml: &ConfigToml) -> MultiAgentV2Config
     }
 }
 
+fn resolve_token_budget_config(
+    config_toml: &ConfigToml,
+    features: &ManagedFeatures,
+) -> std::io::Result<Option<TokenBudgetConfig>> {
+    if !features.enabled(Feature::TokenBudget) {
+        return Ok(None);
+    }
+
+    let token_budget_config = token_budget_toml_config(config_toml.features.as_ref());
+    let reminder_threshold_tokens =
+        token_budget_config.and_then(|config| config.reminder_threshold_tokens);
+    if reminder_threshold_tokens.is_some_and(|tokens| tokens <= 0) {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "features.token_budget.reminder_threshold_tokens must be positive",
+        ));
+    }
+
+    let reminder_message_template = token_budget_config
+        .and_then(|config| config.reminder_message_template.clone())
+        .unwrap_or_else(|| DEFAULT_TOKEN_BUDGET_REMINDER_MESSAGE_TEMPLATE.to_string());
+    if reminder_message_template.trim().is_empty() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "features.token_budget.reminder_message_template must not be empty",
+        ));
+    }
+    if reminder_message_template.len() > TOKEN_BUDGET_REMINDER_MESSAGE_TEMPLATE_MAX_BYTES {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!(
+                "features.token_budget.reminder_message_template must not exceed {TOKEN_BUDGET_REMINDER_MESSAGE_TEMPLATE_MAX_BYTES} bytes"
+            ),
+        ));
+    }
+
+    Ok(Some(TokenBudgetConfig {
+        reminder_threshold_tokens,
+        reminder_message_template,
+    }))
+}
+
 fn resolve_rollout_budget_config(
     config_toml: &ConfigToml,
     features: &ManagedFeatures,
@@ -2630,6 +2696,13 @@ fn code_mode_toml_config(features: Option<&FeaturesToml>) -> Option<&CodeModeCon
 
 fn multi_agent_v2_toml_config(features: Option<&FeaturesToml>) -> Option<&MultiAgentV2ConfigToml> {
     match features?.multi_agent_v2.as_ref()? {
+        FeatureToml::Enabled(_) => None,
+        FeatureToml::Config(config) => Some(config),
+    }
+}
+
+fn token_budget_toml_config(features: Option<&FeaturesToml>) -> Option<&TokenBudgetConfigToml> {
+    match features?.token_budget.as_ref()? {
         FeatureToml::Enabled(_) => None,
         FeatureToml::Config(config) => Some(config),
     }
@@ -3287,6 +3360,7 @@ impl Config {
             resolve_experimental_request_user_input_enabled(&cfg);
         let code_mode = resolve_code_mode_config(&cfg);
         let multi_agent_v2 = resolve_multi_agent_v2_config(&cfg);
+        let token_budget = resolve_token_budget_config(&cfg, &features)?;
         let rollout_budget = resolve_rollout_budget_config(&cfg, &features)?;
         let current_time_reminder = resolve_current_time_reminder_config(&cfg, &features)?;
         let terminal_resize_reflow = resolve_terminal_resize_reflow_config(&cfg);
@@ -3830,6 +3904,7 @@ impl Config {
             background_terminal_max_timeout,
             ghost_snapshot,
             multi_agent_v2,
+            token_budget,
             rollout_budget,
             current_time_reminder,
             features,

--- a/codex-rs/core/src/context/mod.rs
+++ b/codex-rs/core/src/context/mod.rs
@@ -73,6 +73,7 @@ pub(crate) use rollout_budget::RolloutBudgetContext;
 pub(crate) use subagent_notification::SubagentNotification;
 pub(crate) use token_budget_context::TokenBudgetContext;
 pub(crate) use token_budget_context::TokenBudgetRemainingContext;
+pub(crate) use token_budget_context::TokenBudgetReminder;
 pub(crate) use turn_aborted::TurnAborted;
 pub(crate) use user_instructions::UserInstructions;
 pub(crate) use user_shell_command::UserShellCommand;

--- a/codex-rs/core/src/context/token_budget_context.rs
+++ b/codex-rs/core/src/context/token_budget_context.rs
@@ -8,7 +8,7 @@ pub(crate) struct TokenBudgetContext {
     first_window_id: Uuid,
     previous_window_id: Option<Uuid>,
     window_id: Uuid,
-    tokens_left: i64,
+    mcp_result: Option<String>,
 }
 
 impl TokenBudgetContext {
@@ -17,14 +17,14 @@ impl TokenBudgetContext {
         first_window_id: Uuid,
         previous_window_id: Option<Uuid>,
         window_id: Uuid,
-        tokens_left: i64,
+        mcp_result: Option<String>,
     ) -> Self {
         Self {
             thread_id,
             first_window_id,
             previous_window_id,
             window_id,
-            tokens_left,
+            mcp_result,
         }
     }
 }
@@ -49,9 +49,13 @@ impl ContextualUserFragment for TokenBudgetContext {
             .previous_window_id
             .map_or_else(|| "none".to_string(), |window_id| window_id.to_string());
         let window_id = self.window_id;
-        let tokens_left = self.tokens_left;
+        let mcp_result = self
+            .mcp_result
+            .as_deref()
+            .map(|result| format!("\n{result}"))
+            .unwrap_or_default();
         format!(
-            "Thread id {thread_id}.\nFirst context window id {first_window_id}.\nPrevious context window id {previous_window_id}.\nCurrent context window id {window_id}.\nYou have {tokens_left} tokens left in this context window."
+            "Thread id {thread_id}.\nFirst context window id {first_window_id}.\nPrevious context window id {previous_window_id}.\nCurrent context window id {window_id}.{mcp_result}"
         )
     }
 }

--- a/codex-rs/core/src/context/token_budget_context.rs
+++ b/codex-rs/core/src/context/token_budget_context.rs
@@ -39,24 +39,25 @@ impl ContextualUserFragment for TokenBudgetContext {
     }
 
     fn type_markers() -> (&'static str, &'static str) {
-        ("<token_budget>\n", "\n</token_budget>")
+        ("", "")
     }
 
     fn body(&self) -> String {
         let thread_id = self.thread_id;
         let first_window_id = self.first_window_id;
-        let previous_window_id = self
-            .previous_window_id
-            .map_or_else(|| "none".to_string(), |window_id| window_id.to_string());
         let window_id = self.window_id;
-        let mcp_result = self
-            .mcp_result
-            .as_deref()
-            .map(|result| format!("\n{result}"))
-            .unwrap_or_default();
-        format!(
-            "Thread id {thread_id}.\nFirst context window id {first_window_id}.\nPrevious context window id {previous_window_id}.\nCurrent context window id {window_id}.{mcp_result}"
-        )
+        let mut lines = vec![
+            format!("Thread id {thread_id}."),
+            format!("First context window id: {first_window_id}"),
+            format!("Current context window id: {window_id}"),
+        ];
+        if let Some(previous_window_id) = self.previous_window_id {
+            lines.push(format!("Previous context window id: {previous_window_id}"));
+        }
+        if let Some(mcp_result) = &self.mcp_result {
+            lines.push(mcp_result.clone());
+        }
+        lines.join("\n")
     }
 }
 
@@ -87,7 +88,7 @@ impl ContextualUserFragment for TokenBudgetRemainingContext {
     }
 
     fn type_markers() -> (&'static str, &'static str) {
-        ("<token_budget>\n", "\n</token_budget>")
+        ("", "")
     }
 
     fn body(&self) -> String {
@@ -123,7 +124,7 @@ impl ContextualUserFragment for TokenBudgetReminder {
     }
 
     fn type_markers() -> (&'static str, &'static str) {
-        ("<token_budget>\n", "\n</token_budget>")
+        ("", "")
     }
 
     fn body(&self) -> String {

--- a/codex-rs/core/src/context/token_budget_context.rs
+++ b/codex-rs/core/src/context/token_budget_context.rs
@@ -5,14 +5,24 @@ use uuid::Uuid;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct TokenBudgetContext {
     thread_id: ThreadId,
+    first_window_id: Uuid,
+    previous_window_id: Option<Uuid>,
     window_id: Uuid,
     tokens_left: i64,
 }
 
 impl TokenBudgetContext {
-    pub(crate) fn new(thread_id: ThreadId, window_id: Uuid, tokens_left: i64) -> Self {
+    pub(crate) fn new(
+        thread_id: ThreadId,
+        first_window_id: Uuid,
+        previous_window_id: Option<Uuid>,
+        window_id: Uuid,
+        tokens_left: i64,
+    ) -> Self {
         Self {
             thread_id,
+            first_window_id,
+            previous_window_id,
             window_id,
             tokens_left,
         }
@@ -34,10 +44,14 @@ impl ContextualUserFragment for TokenBudgetContext {
 
     fn body(&self) -> String {
         let thread_id = self.thread_id;
+        let first_window_id = self.first_window_id;
+        let previous_window_id = self
+            .previous_window_id
+            .map_or_else(|| "none".to_string(), |window_id| window_id.to_string());
         let window_id = self.window_id;
         let tokens_left = self.tokens_left;
         format!(
-            "Thread id {thread_id}.\nCurrent context window id {window_id}.\nYou have {tokens_left} tokens left in this context window."
+            "Thread id {thread_id}.\nFirst context window id {first_window_id}.\nPrevious context window id {previous_window_id}.\nCurrent context window id {window_id}.\nYou have {tokens_left} tokens left in this context window."
         )
     }
 }

--- a/codex-rs/core/src/context/token_budget_context.rs
+++ b/codex-rs/core/src/context/token_budget_context.rs
@@ -99,3 +99,34 @@ impl ContextualUserFragment for TokenBudgetRemainingContext {
         }
     }
 }
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TokenBudgetReminder {
+    message: String,
+}
+
+impl TokenBudgetReminder {
+    pub(crate) fn new(message_template: &str, n_remaining: i64) -> Self {
+        Self {
+            message: message_template.replace("{n_remaining}", &n_remaining.to_string()),
+        }
+    }
+}
+
+impl ContextualUserFragment for TokenBudgetReminder {
+    fn role(&self) -> &'static str {
+        "developer"
+    }
+
+    fn markers(&self) -> (&'static str, &'static str) {
+        Self::type_markers()
+    }
+
+    fn type_markers() -> (&'static str, &'static str) {
+        ("<token_budget>\n", "\n</token_budget>")
+    }
+
+    fn body(&self) -> String {
+        self.message.clone()
+    }
+}

--- a/codex-rs/core/src/event_mapping.rs
+++ b/codex-rs/core/src/event_mapping.rs
@@ -34,6 +34,7 @@ const CONTEXTUAL_DEVELOPER_PREFIXES: &[&str] = &[
     REALTIME_CONVERSATION_OPEN_TAG,
     SKILLS_INSTRUCTIONS_OPEN_TAG,
     "<personality_spec>",
+    // Keep recognizing token-budget wrappers persisted by older versions.
     "<token_budget>",
     "<rollout_budget>",
 ];

--- a/codex-rs/core/src/event_mapping_tests.rs
+++ b/codex-rs/core/src/event_mapping_tests.rs
@@ -29,7 +29,7 @@ fn recognizes_skills_instructions_as_contextual_developer_content() {
 }
 
 #[test]
-fn recognizes_token_budget_as_contextual_developer_content() {
+fn recognizes_legacy_token_budget_as_contextual_developer_content() {
     let content = vec![ContentItem::InputText {
         text: "<token_budget>\nYou have 710 tokens left in this context window.\n</token_budget>"
             .to_string(),

--- a/codex-rs/core/src/session/config_lock.rs
+++ b/codex-rs/core/src/session/config_lock.rs
@@ -10,6 +10,7 @@ use codex_features::FeatureToml;
 use codex_features::FeaturesToml;
 use codex_features::MultiAgentV2ConfigToml;
 use codex_features::RolloutBudgetConfigToml;
+use codex_features::TokenBudgetConfigToml;
 use codex_protocol::ThreadId;
 
 use crate::config::Config;
@@ -152,6 +153,12 @@ fn save_config_resolved_fields(
         resolved_config_to_toml(&config.multi_agent_v2, "features.multi_agent_v2")?;
     multi_agent_v2.enabled = Some(config.features.enabled(Feature::MultiAgentV2));
     features.multi_agent_v2 = Some(FeatureToml::Config(multi_agent_v2));
+    if let Some(token_budget) = config.token_budget.as_ref() {
+        let mut token_budget: TokenBudgetConfigToml =
+            resolved_config_to_toml(token_budget, "features.token_budget")?;
+        token_budget.enabled = Some(config.features.enabled(Feature::TokenBudget));
+        features.token_budget = Some(FeatureToml::Config(token_budget));
+    }
     if let Some(rollout_budget) = config.rollout_budget.as_ref() {
         let mut rollout_budget: RolloutBudgetConfigToml =
             resolved_config_to_toml(rollout_budget, "features.rollout_budget")?;
@@ -238,6 +245,14 @@ mod tests {
     async fn lock_contains_prompts_and_materializes_features() {
         let mut sc = crate::session::tests::make_session_configuration_for_tests().await;
         let mut config = (*sc.original_config_do_not_use).clone();
+        config.token_budget = Some(crate::config::TokenBudgetConfig {
+            reminder_threshold_tokens: Some(16_000),
+            reminder_message_template: "Locked reminder: {n_remaining} tokens.".to_string(),
+        });
+        config
+            .features
+            .enable(Feature::TokenBudget)
+            .expect("token_budget should be enableable in tests");
         config.rollout_budget = Some(crate::config::RolloutBudgetConfig {
             limit_tokens: 100_000,
             reminder_interval_tokens: 10_000,
@@ -317,6 +332,17 @@ mod tests {
                 ..
             })
         ));
+
+        assert_eq!(
+            features.token_budget,
+            Some(FeatureToml::Config(TokenBudgetConfigToml {
+                enabled: Some(true),
+                reminder_threshold_tokens: Some(16_000),
+                reminder_message_template: Some(
+                    "Locked reminder: {n_remaining} tokens.".to_string()
+                ),
+            }))
+        );
 
         assert_eq!(
             features.rollout_budget,

--- a/codex-rs/core/src/session/mod.rs
+++ b/codex-rs/core/src/session/mod.rs
@@ -3216,15 +3216,38 @@ impl Session {
         }
         // This is full-context metadata. Steady-state context diffs should not re-emit it.
         if turn_context.config.features.enabled(Feature::TokenBudget)
-            && let Some(model_context_window) = turn_context.model_context_window()
+            && turn_context.model_context_window().is_some()
         {
+            let mcp_result = self
+                .call_tool(
+                    "notes",
+                    "thread_hint",
+                    /*arguments*/ None,
+                    Some(serde_json::json!({
+                        "threadId": self.thread_id().to_string(),
+                    })),
+                )
+                .await
+                .ok()
+                .and_then(|result| {
+                    let text = result
+                        .content
+                        .iter()
+                        .filter_map(|content| {
+                            content.get("text").and_then(serde_json::Value::as_str)
+                        })
+                        .filter(|text| !text.is_empty())
+                        .collect::<Vec<_>>()
+                        .join("\n");
+                    (!text.is_empty()).then_some(text)
+                });
             developer_sections.push(
                 crate::context::TokenBudgetContext::new(
                     self.thread_id(),
                     auto_compact_window_ids.first_window_id,
                     auto_compact_window_ids.previous_window_id,
                     auto_compact_window_ids.window_id,
-                    model_context_window,
+                    mcp_result,
                 )
                 .render(),
             );

--- a/codex-rs/core/src/session/mod.rs
+++ b/codex-rs/core/src/session/mod.rs
@@ -311,6 +311,7 @@ use crate::session_startup_prewarm::SessionStartupPrewarmHandle;
 use crate::shell;
 #[cfg(test)]
 use crate::skills::SkillLoadOutcome;
+use crate::state::AutoCompactWindowIds;
 use crate::state::AutoCompactWindowSnapshot;
 use crate::state::PendingRequestPermissions;
 use crate::state::SessionServices;
@@ -1364,6 +1365,8 @@ impl Session {
             previous_turn_settings,
             reference_context_item,
             window_number,
+            first_window_id,
+            previous_window_id,
             window_id,
         } = self
             .reconstruct_history_from_rollout(turn_context, rollout_items)
@@ -1382,8 +1385,16 @@ impl Session {
         {
             let mut state = self.state.lock().await;
             state.replace_history(history, reference_context_item);
-            let window_id = window_id.unwrap_or_else(|| state.auto_compact_window_id());
-            state.restore_auto_compact_window(window_number, window_id);
+            let fallback_ids = state.auto_compact_window_ids();
+            let window_id = window_id.unwrap_or(fallback_ids.window_id);
+            state.restore_auto_compact_window(
+                window_number,
+                AutoCompactWindowIds {
+                    first_window_id: first_window_id.unwrap_or(window_id),
+                    previous_window_id,
+                    window_id,
+                },
+            );
             state.set_previous_turn_settings(previous_turn_settings.clone());
         }
         let prefix_tokens = if matches!(
@@ -3011,7 +3022,7 @@ impl Session {
             collaboration_mode,
             base_instructions,
             session_source,
-            auto_compact_window_id,
+            auto_compact_window_ids,
         ) = {
             let state = self.state.lock().await;
             (
@@ -3020,7 +3031,7 @@ impl Session {
                 state.session_configuration.collaboration_mode.clone(),
                 state.session_configuration.base_instructions.clone(),
                 state.session_configuration.session_source.clone(),
-                state.auto_compact_window_id(),
+                state.auto_compact_window_ids(),
             )
         };
         if let Some(model_switch_message) =
@@ -3210,7 +3221,9 @@ impl Session {
             developer_sections.push(
                 crate::context::TokenBudgetContext::new(
                     self.thread_id(),
-                    auto_compact_window_id,
+                    auto_compact_window_ids.first_window_id,
+                    auto_compact_window_ids.previous_window_id,
+                    auto_compact_window_ids.window_id,
                     model_context_window,
                 )
                 .render(),
@@ -3309,10 +3322,9 @@ impl Session {
         format!("{thread_id}:{window_number}")
     }
 
-    pub(crate) async fn advance_auto_compact_window(&self) -> (u64, String) {
+    pub(crate) async fn advance_auto_compact_window(&self) -> (u64, AutoCompactWindowIds) {
         let mut state = self.state.lock().await;
-        let (window_number, window_id) = state.advance_auto_compact_window();
-        (window_number, window_id.to_string())
+        state.advance_auto_compact_window()
     }
 
     pub(crate) async fn request_new_context_window(&self) {
@@ -3328,7 +3340,7 @@ impl Session {
             let mut state = self.state.lock().await;
             state.start_new_context_window_if_requested()
         };
-        let (window_number, window_id) = window?;
+        let (window_number, window_ids) = window?;
         let context_items = self.build_initial_context(turn_context).await;
         let turn_context_item = turn_context.to_turn_context_item();
         let replacement_history = context_items;
@@ -3341,7 +3353,9 @@ impl Session {
                 message: String::new(),
                 replacement_history: Some(replacement_history),
                 window_number: Some(window_number),
-                window_id: Some(window_id.to_string()),
+                first_window_id: Some(window_ids.first_window_id.to_string()),
+                previous_window_id: window_ids.previous_window_id.map(|id| id.to_string()),
+                window_id: Some(window_ids.window_id.to_string()),
             }),
             RolloutItem::TurnContext(turn_context_item),
         ])

--- a/codex-rs/core/src/session/rollout_reconstruction.rs
+++ b/codex-rs/core/src/session/rollout_reconstruction.rs
@@ -10,12 +10,16 @@ pub(super) struct RolloutReconstruction {
     pub(super) previous_turn_settings: Option<PreviousTurnSettings>,
     pub(super) reference_context_item: Option<TurnContextItem>,
     pub(super) window_number: u64,
+    pub(super) first_window_id: Option<Uuid>,
+    pub(super) previous_window_id: Option<Uuid>,
     pub(super) window_id: Option<Uuid>,
 }
 
 #[derive(Debug, Clone, Copy)]
 struct ReconstructedWindow {
     number: u64,
+    first_id: Option<Uuid>,
+    previous_id: Option<Uuid>,
     id: Option<Uuid>,
 }
 
@@ -133,6 +137,11 @@ impl Session {
                     {
                         active_segment.window = Some(ReconstructedWindow {
                             number: window_number,
+                            first_id: compacted.first_window_id.as_deref().and_then(parse_uuid_v7),
+                            previous_id: compacted
+                                .previous_window_id
+                                .as_deref()
+                                .and_then(parse_uuid_v7),
                             id: compacted.window_id.as_deref().and_then(parse_uuid_v7),
                         });
                     }
@@ -341,6 +350,8 @@ impl Session {
 
         let window = window.unwrap_or(ReconstructedWindow {
             number: fallback_window_number,
+            first_id: None,
+            previous_id: None,
             id: None,
         });
         RolloutReconstruction {
@@ -348,6 +359,8 @@ impl Session {
             previous_turn_settings,
             reference_context_item,
             window_number: window.number,
+            first_window_id: window.first_id,
+            previous_window_id: window.previous_id,
             window_id: window.id,
         }
     }

--- a/codex-rs/core/src/session/rollout_reconstruction_tests.rs
+++ b/codex-rs/core/src/session/rollout_reconstruction_tests.rs
@@ -829,6 +829,8 @@ async fn record_initial_history_resumed_rollback_drops_incomplete_user_turn_comp
             message: String::new(),
             replacement_history: Some(Vec::new()),
             window_number: None,
+            first_window_id: None,
+            previous_window_id: None,
             window_id: None,
         }),
         RolloutItem::EventMsg(EventMsg::ThreadRolledBack(
@@ -887,6 +889,8 @@ async fn record_initial_history_resumed_does_not_seed_reference_context_item_aft
             message: String::new(),
             replacement_history: Some(Vec::new()),
             window_number: None,
+            first_window_id: None,
+            previous_window_id: None,
             window_id: None,
         }),
     ];
@@ -914,6 +918,8 @@ async fn reconstruct_history_legacy_compaction_without_replacement_history_does_
             message: "legacy summary".to_string(),
             replacement_history: None,
             window_number: None,
+            first_window_id: None,
+            previous_window_id: None,
             window_id: None,
         }),
     ];
@@ -947,6 +953,8 @@ async fn reconstruct_history_legacy_compaction_without_replacement_history_clear
             message: "legacy summary".to_string(),
             replacement_history: None,
             window_number: None,
+            first_window_id: None,
+            previous_window_id: None,
             window_id: None,
         }),
         RolloutItem::EventMsg(EventMsg::TurnStarted(
@@ -1043,6 +1051,8 @@ async fn record_initial_history_resumed_turn_context_after_compaction_reestablis
             message: String::new(),
             replacement_history: Some(Vec::new()),
             window_number: None,
+            first_window_id: None,
+            previous_window_id: None,
             window_id: None,
         }),
         RolloutItem::TurnContext(previous_context_item),
@@ -1196,6 +1206,8 @@ async fn record_initial_history_resumed_aborted_turn_without_id_clears_active_tu
             message: String::new(),
             replacement_history: Some(Vec::new()),
             window_number: None,
+            first_window_id: None,
+            previous_window_id: None,
             window_id: None,
         }),
     ];
@@ -1433,6 +1445,8 @@ async fn record_initial_history_resumed_trailing_incomplete_turn_compaction_clea
             message: String::new(),
             replacement_history: Some(Vec::new()),
             window_number: None,
+            first_window_id: None,
+            previous_window_id: None,
             window_id: None,
         }),
     ];
@@ -1599,6 +1613,8 @@ async fn record_initial_history_resumed_replaced_incomplete_compacted_turn_clear
             message: String::new(),
             replacement_history: Some(Vec::new()),
             window_number: None,
+            first_window_id: None,
+            previous_window_id: None,
             window_id: None,
         }),
         // A newer TurnStarted replaces the incomplete compacted turn without a matching

--- a/codex-rs/core/src/session/tests.rs
+++ b/codex-rs/core/src/session/tests.rs
@@ -1653,11 +1653,15 @@ async fn reconstruct_history_uses_replacement_history_verbatim() {
             metadata: None,
         },
     ];
+    let first_window_id = Uuid::now_v7();
+    let previous_window_id = Uuid::now_v7();
     let window_id = Uuid::now_v7();
     let rollout_items = vec![RolloutItem::Compacted(CompactedItem {
         message: String::new(),
         replacement_history: Some(replacement_history.clone()),
         window_number: Some(42),
+        first_window_id: Some(first_window_id.to_string()),
+        previous_window_id: Some(previous_window_id.to_string()),
         window_id: Some(window_id.to_string()),
     })];
 
@@ -1667,6 +1671,8 @@ async fn reconstruct_history_uses_replacement_history_verbatim() {
 
     assert_eq!(reconstructed.history, replacement_history);
     assert_eq!(42, reconstructed.window_number);
+    assert_eq!(Some(first_window_id), reconstructed.first_window_id);
+    assert_eq!(Some(previous_window_id), reconstructed.previous_window_id);
     assert_eq!(Some(window_id), reconstructed.window_id);
 }
 
@@ -3059,6 +3065,8 @@ async fn thread_rollback_restores_cleared_reference_context_item_after_compactio
         user_message("turn 1 user"),
         user_message("summary after compaction"),
     ];
+    let first_window_id = Uuid::now_v7();
+    let previous_window_id = Uuid::now_v7();
     let compacted_window_id = Uuid::now_v7();
 
     sess.persist_rollout_items(&[
@@ -3102,6 +3110,8 @@ async fn thread_rollback_restores_cleared_reference_context_item_after_compactio
             message: "summary after compaction".to_string(),
             replacement_history: Some(compacted_history.clone()),
             window_number: Some(7),
+            first_window_id: Some(first_window_id.to_string()),
+            previous_window_id: Some(previous_window_id.to_string()),
             window_id: Some(compacted_window_id.to_string()),
         }),
         RolloutItem::EventMsg(EventMsg::TurnComplete(TurnCompleteEvent {
@@ -3152,7 +3162,14 @@ async fn thread_rollback_restores_cleared_reference_context_item_after_compactio
     .await;
     {
         let mut state = sess.state.lock().await;
-        state.restore_auto_compact_window(/*window_number*/ 99, Uuid::now_v7());
+        state.restore_auto_compact_window(
+            /*window_number*/ 99,
+            AutoCompactWindowIds {
+                first_window_id: Uuid::now_v7(),
+                previous_window_id: Some(Uuid::now_v7()),
+                window_id: Uuid::now_v7(),
+            },
+        );
     }
 
     handlers::thread_rollback(&sess, "sub-1".to_string(), /*num_turns*/ 1).await;
@@ -3162,8 +3179,12 @@ async fn thread_rollback_restores_cleared_reference_context_item_after_compactio
     assert_eq!(sess.clone_history().await.raw_items(), compacted_history);
     assert!(sess.reference_context_item().await.is_none());
     assert_eq!(
-        sess.state.lock().await.auto_compact_window_id(),
-        compacted_window_id
+        sess.state.lock().await.auto_compact_window_ids(),
+        AutoCompactWindowIds {
+            first_window_id,
+            previous_window_id: Some(previous_window_id),
+            window_id: compacted_window_id,
+        }
     );
     assert!(sess.current_window_id().await.ends_with(":7"));
 }
@@ -9910,12 +9931,14 @@ async fn sample_rollout(
     let user_messages1 = collect_user_messages(&snapshot1);
     let rebuilt1 = compact::build_compacted_history(Vec::new(), &user_messages1, summary1);
     live_history.replace(rebuilt1);
-    let (window_number, window_id) = session.advance_auto_compact_window().await;
+    let (window_number, window_ids) = session.advance_auto_compact_window().await;
     rollout_items.push(RolloutItem::Compacted(CompactedItem {
         message: summary1.to_string(),
         replacement_history: None,
         window_number: Some(window_number),
-        window_id: Some(window_id),
+        first_window_id: Some(window_ids.first_window_id.to_string()),
+        previous_window_id: window_ids.previous_window_id.map(|id| id.to_string()),
+        window_id: Some(window_ids.window_id.to_string()),
     }));
 
     let user2 = ResponseItem::Message {
@@ -9955,12 +9978,14 @@ async fn sample_rollout(
     let user_messages2 = collect_user_messages(&snapshot2);
     let rebuilt2 = compact::build_compacted_history(Vec::new(), &user_messages2, summary2);
     live_history.replace(rebuilt2);
-    let (window_number, window_id) = session.advance_auto_compact_window().await;
+    let (window_number, window_ids) = session.advance_auto_compact_window().await;
     rollout_items.push(RolloutItem::Compacted(CompactedItem {
         message: summary2.to_string(),
         replacement_history: None,
         window_number: Some(window_number),
-        window_id: Some(window_id),
+        first_window_id: Some(window_ids.first_window_id.to_string()),
+        previous_window_id: window_ids.previous_window_id.map(|id| id.to_string()),
+        window_id: Some(window_ids.window_id.to_string()),
     }));
 
     let user3 = ResponseItem::Message {

--- a/codex-rs/core/src/session/token_budget.rs
+++ b/codex-rs/core/src/session/token_budget.rs
@@ -5,40 +5,61 @@ use codex_features::Feature;
 
 const TOKEN_BUDGET_USAGE_THRESHOLDS: [i64; 3] = [25, 50, 75];
 
-pub(super) async fn maybe_record_token_budget_remaining_context(
+pub(super) async fn maybe_record(
     sess: &Session,
     turn_context: &TurnContext,
     tokens_before_sampling: i64,
     tokens_after_sampling: i64,
+    tokens_until_compaction: i64,
 ) {
     if !turn_context.config.features.enabled(Feature::TokenBudget) {
         return;
     }
-    let Some(model_context_window) = turn_context.model_context_window() else {
-        return;
-    };
-    if model_context_window <= 0 || tokens_after_sampling <= tokens_before_sampling {
-        return;
+
+    let mut response_items = Vec::new();
+    if let Some(model_context_window) = turn_context.model_context_window()
+        && model_context_window > 0
+        && tokens_after_sampling > tokens_before_sampling
+    {
+        let tokens_before_sampling = tokens_before_sampling.max(0);
+        let tokens_after_sampling = tokens_after_sampling.max(0);
+        let crossed_threshold = TOKEN_BUDGET_USAGE_THRESHOLDS.iter().any(|threshold| {
+            tokens_before_sampling.saturating_mul(100)
+                < model_context_window.saturating_mul(*threshold)
+                && tokens_after_sampling.saturating_mul(100)
+                    >= model_context_window.saturating_mul(*threshold)
+        });
+        if crossed_threshold {
+            let tokens_left = model_context_window
+                .saturating_sub(tokens_after_sampling)
+                .max(0);
+            response_items.push(ContextualUserFragment::into(
+                crate::context::TokenBudgetRemainingContext::new(tokens_left),
+            ));
+        }
     }
 
-    let tokens_before_sampling = tokens_before_sampling.max(0);
-    let tokens_after_sampling = tokens_after_sampling.max(0);
-    let crossed_threshold = TOKEN_BUDGET_USAGE_THRESHOLDS.iter().any(|threshold| {
-        tokens_before_sampling.saturating_mul(100) < model_context_window.saturating_mul(*threshold)
-            && tokens_after_sampling.saturating_mul(100)
-                >= model_context_window.saturating_mul(*threshold)
-    });
-    if !crossed_threshold {
-        return;
+    if let Some(config) = turn_context.config.token_budget.as_ref().filter(|config| {
+        config
+            .reminder_threshold_tokens
+            .is_some_and(|threshold| tokens_until_compaction <= threshold)
+    }) {
+        let reminder_due = {
+            let mut state = sess.state.lock().await;
+            state.claim_token_budget_reminder()
+        };
+        if reminder_due {
+            response_items.push(ContextualUserFragment::into(
+                crate::context::TokenBudgetReminder::new(
+                    &config.reminder_message_template,
+                    tokens_until_compaction,
+                ),
+            ));
+        }
     }
 
-    let tokens_left = model_context_window
-        .saturating_sub(tokens_after_sampling)
-        .max(0);
-
-    let response_item = ContextualUserFragment::into(
-        crate::context::TokenBudgetRemainingContext::new(tokens_left),
-    );
-    sess.record_conversation_items(turn_context, std::slice::from_ref(&response_item))
-        .await;
+    if !response_items.is_empty() {
+        sess.record_conversation_items(turn_context, &response_items)
+            .await;
+    }
 }

--- a/codex-rs/core/src/session/token_budget.rs
+++ b/codex-rs/core/src/session/token_budget.rs
@@ -3,63 +3,35 @@ use super::turn_context::TurnContext;
 use crate::context::ContextualUserFragment;
 use codex_features::Feature;
 
-const TOKEN_BUDGET_USAGE_THRESHOLDS: [i64; 3] = [25, 50, 75];
-
 pub(super) async fn maybe_record(
     sess: &Session,
     turn_context: &TurnContext,
-    tokens_before_sampling: i64,
-    tokens_after_sampling: i64,
     tokens_until_compaction: i64,
 ) {
     if !turn_context.config.features.enabled(Feature::TokenBudget) {
         return;
     }
 
-    let mut response_items = Vec::new();
-    if let Some(model_context_window) = turn_context.model_context_window()
-        && model_context_window > 0
-        && tokens_after_sampling > tokens_before_sampling
-    {
-        let tokens_before_sampling = tokens_before_sampling.max(0);
-        let tokens_after_sampling = tokens_after_sampling.max(0);
-        let crossed_threshold = TOKEN_BUDGET_USAGE_THRESHOLDS.iter().any(|threshold| {
-            tokens_before_sampling.saturating_mul(100)
-                < model_context_window.saturating_mul(*threshold)
-                && tokens_after_sampling.saturating_mul(100)
-                    >= model_context_window.saturating_mul(*threshold)
-        });
-        if crossed_threshold {
-            let tokens_left = model_context_window
-                .saturating_sub(tokens_after_sampling)
-                .max(0);
-            response_items.push(ContextualUserFragment::into(
-                crate::context::TokenBudgetRemainingContext::new(tokens_left),
-            ));
-        }
-    }
-
-    if let Some(config) = turn_context.config.token_budget.as_ref().filter(|config| {
+    let Some(config) = turn_context.config.token_budget.as_ref().filter(|config| {
         config
             .reminder_threshold_tokens
             .is_some_and(|threshold| tokens_until_compaction <= threshold)
-    }) {
-        let reminder_due = {
-            let mut state = sess.state.lock().await;
-            state.claim_token_budget_reminder()
-        };
-        if reminder_due {
-            response_items.push(ContextualUserFragment::into(
-                crate::context::TokenBudgetReminder::new(
-                    &config.reminder_message_template,
-                    tokens_until_compaction,
-                ),
-            ));
-        }
+    }) else {
+        return;
+    };
+
+    let reminder_due = {
+        let mut state = sess.state.lock().await;
+        state.claim_token_budget_reminder()
+    };
+    if !reminder_due {
+        return;
     }
 
-    if !response_items.is_empty() {
-        sess.record_conversation_items(turn_context, &response_items)
-            .await;
-    }
+    let response_item = ContextualUserFragment::into(crate::context::TokenBudgetReminder::new(
+        &config.reminder_message_template,
+        tokens_until_compaction,
+    ));
+    sess.record_conversation_items(turn_context, std::slice::from_ref(&response_item))
+        .await;
 }

--- a/codex-rs/core/src/session/turn.rs
+++ b/codex-rs/core/src/session/turn.rs
@@ -254,8 +254,7 @@ pub(crate) async fn run_turn(
                 window_id,
                 CodexResponsesRequestKind::Turn,
             );
-            let tokens_before_sampling = sess.get_total_token_usage().await;
-            let (sampling_request_output, sampling_request_input) = run_sampling_request(
+            run_sampling_request(
                 Arc::clone(&sess),
                 Arc::clone(&turn_context),
                 Arc::clone(&turn_extension_data),
@@ -265,17 +264,11 @@ pub(crate) async fn run_turn(
                 sampling_request_input,
                 cancellation_token.child_token(),
             )
-            .await?;
-
-            Ok((
-                tokens_before_sampling,
-                sampling_request_output,
-                sampling_request_input,
-            ))
+            .await
         }
         .await;
         match sampling_request_result {
-            Ok((tokens_before_sampling, sampling_request_output, sampling_request_input)) => {
+            Ok((sampling_request_output, sampling_request_input)) => {
                 let SamplingRequestResult {
                     needs_follow_up: model_needs_follow_up,
                     last_agent_message: sampling_request_last_agent_message,
@@ -326,8 +319,6 @@ pub(crate) async fn run_turn(
                 super::token_budget::maybe_record(
                     sess.as_ref(),
                     turn_context.as_ref(),
-                    tokens_before_sampling,
-                    tokens_after_sampling,
                     tokens_until_compaction,
                 )
                 .await;

--- a/codex-rs/core/src/session/turn.rs
+++ b/codex-rs/core/src/session/turn.rs
@@ -313,11 +313,22 @@ pub(crate) async fn run_turn(
                 );
 
                 let tokens_after_sampling = token_status.active_context_tokens;
-                super::token_budget::maybe_record_token_budget_remaining_context(
+                let full_context_remaining = token_status
+                    .full_context_window_limit
+                    .map_or(i64::MAX, |limit| {
+                        limit.saturating_sub(tokens_after_sampling)
+                    });
+                let tokens_until_compaction = token_status
+                    .auto_compact_scope_limit
+                    .saturating_sub(token_status.auto_compact_scope_tokens)
+                    .min(full_context_remaining)
+                    .max(0);
+                super::token_budget::maybe_record(
                     sess.as_ref(),
                     turn_context.as_ref(),
                     tokens_before_sampling,
                     tokens_after_sampling,
+                    tokens_until_compaction,
                 )
                 .await;
 

--- a/codex-rs/core/src/state/auto_compact_window.rs
+++ b/codex-rs/core/src/state/auto_compact_window.rs
@@ -30,6 +30,7 @@ pub(super) struct AutoCompactWindow {
     /// not the growth itself; server-observed usage replaces estimated
     /// resume/recompute baselines when available.
     prefill_input_tokens: Option<AutoCompactWindowPrefill>,
+    token_budget_reminder_delivered: bool,
 }
 
 impl AutoCompactWindow {
@@ -44,6 +45,7 @@ impl AutoCompactWindow {
             },
             new_context_window_requested: false,
             prefill_input_tokens: None,
+            token_budget_reminder_delivered: false,
         }
     }
 
@@ -69,7 +71,12 @@ impl AutoCompactWindow {
         self.ids.previous_window_id = Some(self.ids.window_id);
         self.ids.window_id = Uuid::now_v7();
         self.new_context_window_requested = false;
+        self.token_budget_reminder_delivered = false;
         (self.window_number, self.ids)
+    }
+
+    pub(super) fn claim_token_budget_reminder(&mut self) -> bool {
+        !std::mem::replace(&mut self.token_budget_reminder_delivered, true)
     }
 
     pub(super) fn request_new_context_window(&mut self) {
@@ -154,6 +161,8 @@ mod tests {
         );
         assert_eq!(window.window_number(), 3);
         assert_eq!(window.ids().window_id, restored_window_id);
+        assert!(window.claim_token_budget_reminder());
+        assert!(!window.claim_token_budget_reminder());
         window.request_new_context_window();
         assert!(window.take_new_context_window_request());
         assert!(!window.take_new_context_window_request());
@@ -167,6 +176,7 @@ mod tests {
         assert_eq!(ids.window_id.get_version_num(), 7);
         assert_ne!(ids.window_id, restored_window_id);
         assert!(!window.take_new_context_window_request());
+        assert!(window.claim_token_budget_reminder());
 
         assert_eq!(
             window.snapshot(),

--- a/codex-rs/core/src/state/auto_compact_window.rs
+++ b/codex-rs/core/src/state/auto_compact_window.rs
@@ -2,6 +2,13 @@ use codex_protocol::protocol::TokenUsage;
 use uuid::Uuid;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct AutoCompactWindowIds {
+    pub(crate) first_window_id: Uuid,
+    pub(crate) previous_window_id: Option<Uuid>,
+    pub(crate) window_id: Uuid,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct AutoCompactWindowSnapshot {
     pub(crate) prefill_input_tokens: Option<i64>,
 }
@@ -15,7 +22,7 @@ enum AutoCompactWindowPrefill {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) struct AutoCompactWindow {
     window_number: u64,
-    window_id: Uuid,
+    ids: AutoCompactWindowIds,
     new_context_window_requested: bool,
     /// Absolute input-token baseline for the current compaction window.
     ///
@@ -27,9 +34,14 @@ pub(super) struct AutoCompactWindow {
 
 impl AutoCompactWindow {
     pub(super) fn new() -> Self {
+        let window_id = Uuid::now_v7();
         Self {
             window_number: 0,
-            window_id: Uuid::now_v7(),
+            ids: AutoCompactWindowIds {
+                first_window_id: window_id,
+                previous_window_id: None,
+                window_id,
+            },
             new_context_window_requested: false,
             prefill_input_tokens: None,
         }
@@ -43,20 +55,21 @@ impl AutoCompactWindow {
         self.window_number
     }
 
-    pub(super) fn window_id(&self) -> Uuid {
-        self.window_id
+    pub(super) fn ids(&self) -> AutoCompactWindowIds {
+        self.ids
     }
 
-    pub(super) fn restore(&mut self, window_number: u64, window_id: Uuid) {
+    pub(super) fn restore(&mut self, window_number: u64, ids: AutoCompactWindowIds) {
         self.window_number = window_number;
-        self.window_id = window_id;
+        self.ids = ids;
     }
 
-    pub(super) fn advance(&mut self) -> (u64, Uuid) {
+    pub(super) fn advance(&mut self) -> (u64, AutoCompactWindowIds) {
         self.window_number = self.window_number.saturating_add(1);
-        self.window_id = Uuid::now_v7();
+        self.ids.previous_window_id = Some(self.ids.window_id);
+        self.ids.window_id = Uuid::now_v7();
         self.new_context_window_requested = false;
-        (self.window_number, self.window_id)
+        (self.window_number, self.ids)
     }
 
     pub(super) fn request_new_context_window(&mut self) {
@@ -118,21 +131,41 @@ mod tests {
         let mut window = AutoCompactWindow::new();
 
         assert_eq!(window.window_number(), 0);
-        assert_eq!(window.window_id().get_version_num(), 7);
+        let initial_window_id = window.ids().window_id;
+        assert_eq!(initial_window_id.get_version_num(), 7);
+        assert_eq!(
+            window.ids(),
+            AutoCompactWindowIds {
+                first_window_id: initial_window_id,
+                previous_window_id: None,
+                window_id: initial_window_id,
+            }
+        );
+        let first_window_id = initial_window_id;
         let restored_window_id = Uuid::now_v7();
-        window.restore(/*window_number*/ 3, restored_window_id);
+        let restored_previous_window_id = Uuid::now_v7();
+        window.restore(
+            /*window_number*/ 3,
+            AutoCompactWindowIds {
+                first_window_id,
+                previous_window_id: Some(restored_previous_window_id),
+                window_id: restored_window_id,
+            },
+        );
         assert_eq!(window.window_number(), 3);
-        assert_eq!(window.window_id(), restored_window_id);
+        assert_eq!(window.ids().window_id, restored_window_id);
         window.request_new_context_window();
         assert!(window.take_new_context_window_request());
         assert!(!window.take_new_context_window_request());
         window.request_new_context_window();
-        let (window_number, window_id) = window.advance();
+        let (window_number, ids) = window.advance();
         assert_eq!(window_number, 4);
         assert_eq!(window.window_number(), 4);
-        assert_eq!(window.window_id(), window_id);
-        assert_eq!(window_id.get_version_num(), 7);
-        assert_ne!(window_id, restored_window_id);
+        assert_eq!(window.ids(), ids);
+        assert_eq!(ids.first_window_id, first_window_id);
+        assert_eq!(ids.previous_window_id, Some(restored_window_id));
+        assert_eq!(ids.window_id.get_version_num(), 7);
+        assert_ne!(ids.window_id, restored_window_id);
         assert!(!window.take_new_context_window_request());
 
         assert_eq!(

--- a/codex-rs/core/src/state/mod.rs
+++ b/codex-rs/core/src/state/mod.rs
@@ -5,6 +5,7 @@ mod session;
 mod turn;
 
 pub(crate) use additional_context::AdditionalContextStore;
+pub(crate) use auto_compact_window::AutoCompactWindowIds;
 pub(crate) use auto_compact_window::AutoCompactWindowSnapshot;
 pub(crate) use service::SessionServices;
 pub(crate) use session::SessionState;

--- a/codex-rs/core/src/state/session.rs
+++ b/codex-rs/core/src/state/session.rs
@@ -6,10 +6,10 @@ use codex_sandboxing::policy_transforms::merge_permission_profiles;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::collections::VecDeque;
-use uuid::Uuid;
 
 use super::AdditionalContextStore;
 use super::auto_compact_window::AutoCompactWindow;
+use super::auto_compact_window::AutoCompactWindowIds;
 use super::auto_compact_window::AutoCompactWindowSnapshot;
 use crate::context_manager::ContextManager;
 use crate::session::PreviousTurnSettings;
@@ -152,15 +152,19 @@ impl SessionState {
         self.auto_compact_window.window_number()
     }
 
-    pub(crate) fn auto_compact_window_id(&self) -> Uuid {
-        self.auto_compact_window.window_id()
+    pub(crate) fn auto_compact_window_ids(&self) -> AutoCompactWindowIds {
+        self.auto_compact_window.ids()
     }
 
-    pub(crate) fn restore_auto_compact_window(&mut self, window_number: u64, window_id: Uuid) {
-        self.auto_compact_window.restore(window_number, window_id);
+    pub(crate) fn restore_auto_compact_window(
+        &mut self,
+        window_number: u64,
+        ids: AutoCompactWindowIds,
+    ) {
+        self.auto_compact_window.restore(window_number, ids);
     }
 
-    pub(crate) fn advance_auto_compact_window(&mut self) -> (u64, Uuid) {
+    pub(crate) fn advance_auto_compact_window(&mut self) -> (u64, AutoCompactWindowIds) {
         self.auto_compact_window.advance()
     }
 
@@ -168,7 +172,9 @@ impl SessionState {
         self.auto_compact_window.request_new_context_window();
     }
 
-    pub(crate) fn start_new_context_window_if_requested(&mut self) -> Option<(u64, Uuid)> {
+    pub(crate) fn start_new_context_window_if_requested(
+        &mut self,
+    ) -> Option<(u64, AutoCompactWindowIds)> {
         if !self.auto_compact_window.take_new_context_window_request() {
             return None;
         }

--- a/codex-rs/core/src/state/session.rs
+++ b/codex-rs/core/src/state/session.rs
@@ -148,6 +148,10 @@ impl SessionState {
         self.auto_compact_window.snapshot()
     }
 
+    pub(crate) fn claim_token_budget_reminder(&mut self) -> bool {
+        self.auto_compact_window.claim_token_budget_reminder()
+    }
+
     pub(crate) fn auto_compact_window_number(&self) -> u64 {
         self.auto_compact_window.window_number()
     }

--- a/codex-rs/core/tests/suite/snapshots/all__suite__token_budget__token_budget_new_context_window_tool_full_context.snap
+++ b/codex-rs/core/tests/suite/snapshots/all__suite__token_budget__token_budget_new_context_window_tool_full_context.snap
@@ -9,7 +9,7 @@ Scenario: New context window tool installs fresh full context before the next fo
 00:message/developer[3]:
     [01] <PERMISSIONS_INSTRUCTIONS>
     [02] <SKILLS_INSTRUCTIONS>
-    [03] <token_budget>\nThread id <THREAD_ID>.\nFirst context window id <FIRST_WINDOW_ID>.\nPrevious context window id <FIRST_WINDOW_ID>.\nCurrent context window id <WINDOW_ID>.\n</token_budget>
+    [03] Thread id <THREAD_ID>.\nFirst context window id: <FIRST_WINDOW_ID>\nCurrent context window id: <WINDOW_ID>\nPrevious context window id: <FIRST_WINDOW_ID>
 01:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
 02:function_call/update_plan
 03:function_call_output:Plan updated

--- a/codex-rs/core/tests/suite/snapshots/all__suite__token_budget__token_budget_new_context_window_tool_full_context.snap
+++ b/codex-rs/core/tests/suite/snapshots/all__suite__token_budget__token_budget_new_context_window_tool_full_context.snap
@@ -1,5 +1,6 @@
 ---
 source: core/tests/suite/token_budget.rs
+assertion_line: 539
 expression: snapshot
 ---
 Scenario: New context window tool installs fresh full context before the next follow-up request.
@@ -8,7 +9,7 @@ Scenario: New context window tool installs fresh full context before the next fo
 00:message/developer[3]:
     [01] <PERMISSIONS_INSTRUCTIONS>
     [02] <SKILLS_INSTRUCTIONS>
-    [03] <token_budget>\nThread id <THREAD_ID>.\nCurrent context window id <UUID>.\nYou have 121600 tokens left in this context window.\n</token_budget>
+    [03] <token_budget>\nThread id <THREAD_ID>.\nFirst context window id <FIRST_WINDOW_ID>.\nPrevious context window id <FIRST_WINDOW_ID>.\nCurrent context window id <WINDOW_ID>.\nYou have 121600 tokens left in this context window.\n</token_budget>
 01:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
 02:function_call/update_plan
 03:function_call_output:Plan updated

--- a/codex-rs/core/tests/suite/snapshots/all__suite__token_budget__token_budget_new_context_window_tool_full_context.snap
+++ b/codex-rs/core/tests/suite/snapshots/all__suite__token_budget__token_budget_new_context_window_tool_full_context.snap
@@ -1,6 +1,6 @@
 ---
 source: core/tests/suite/token_budget.rs
-assertion_line: 539
+assertion_line: 588
 expression: snapshot
 ---
 Scenario: New context window tool installs fresh full context before the next follow-up request.
@@ -9,7 +9,7 @@ Scenario: New context window tool installs fresh full context before the next fo
 00:message/developer[3]:
     [01] <PERMISSIONS_INSTRUCTIONS>
     [02] <SKILLS_INSTRUCTIONS>
-    [03] <token_budget>\nThread id <THREAD_ID>.\nFirst context window id <FIRST_WINDOW_ID>.\nPrevious context window id <FIRST_WINDOW_ID>.\nCurrent context window id <WINDOW_ID>.\nYou have 121600 tokens left in this context window.\n</token_budget>
+    [03] <token_budget>\nThread id <THREAD_ID>.\nFirst context window id <FIRST_WINDOW_ID>.\nPrevious context window id <FIRST_WINDOW_ID>.\nCurrent context window id <WINDOW_ID>.\n</token_budget>
 01:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
 02:function_call/update_plan
 03:function_call_output:Plan updated

--- a/codex-rs/core/tests/suite/token_budget.rs
+++ b/codex-rs/core/tests/suite/token_budget.rs
@@ -1,4 +1,6 @@
 use anyhow::Result;
+use codex_config::types::McpServerConfig;
+use codex_config::types::McpServerTransportConfig;
 use codex_features::Feature;
 use codex_model_provider_info::built_in_model_providers;
 use codex_protocol::protocol::EventMsg;
@@ -17,15 +19,18 @@ use core_test_support::responses::mount_sse_sequence;
 use core_test_support::responses::sse;
 use core_test_support::responses::start_mock_server;
 use core_test_support::skip_if_no_network;
+use core_test_support::stdio_server_bin;
 use core_test_support::test_codex::local;
 use core_test_support::test_codex::test_codex;
 use core_test_support::wait_for_event;
+use core_test_support::wait_for_mcp_server;
 use pretty_assertions::assert_eq;
 use serde_json::Value;
 use serde_json::json;
+use std::collections::HashMap;
+use std::time::Duration;
 
 const CONFIGURED_CONTEXT_WINDOW: i64 = 128_000;
-const EFFECTIVE_CONTEXT_WINDOW: i64 = CONFIGURED_CONTEXT_WINDOW * 95 / 100;
 
 fn token_budget_texts(request: &ResponsesRequest) -> Vec<String> {
     request
@@ -38,11 +43,10 @@ fn token_budget_texts(request: &ResponsesRequest) -> Vec<String> {
 fn token_budget_window_ids(
     text: &str,
     thread_id: codex_protocol::ThreadId,
-    tokens_left: i64,
 ) -> (String, Option<String>, String) {
     let captures = assert_regex_match(
         &format!(
-            r"^<token_budget>\nThread id {thread_id}\.\nFirst context window id ([0-9a-f-]{{36}})\.\nPrevious context window id (none|[0-9a-f-]{{36}})\.\nCurrent context window id ([0-9a-f-]{{36}})\.\nYou have {tokens_left} tokens left in this context window\.\n</token_budget>$"
+            r"^<token_budget>\nThread id {thread_id}\.\nFirst context window id ([0-9a-f-]{{36}})\.\nPrevious context window id (none|[0-9a-f-]{{36}})\.\nCurrent context window id ([0-9a-f-]{{36}})\.\n</token_budget>$"
         ),
         text,
     );
@@ -112,17 +116,97 @@ async fn token_budget_context_is_only_emitted_with_full_context() -> Result<()> 
     let thread_id = test.session_configured.thread_id;
     let initial_token_budget = token_budget_texts(&requests[0]);
     assert_eq!(initial_token_budget.len(), 1);
-    let (first_window_id, previous_window_id, window_id) = token_budget_window_ids(
-        &initial_token_budget[0],
-        thread_id,
-        EFFECTIVE_CONTEXT_WINDOW,
-    );
+    let (first_window_id, previous_window_id, window_id) =
+        token_budget_window_ids(&initial_token_budget[0], thread_id);
     assert_eq!(previous_window_id, None);
     assert_eq!(first_window_id, window_id);
     assert_eq!(
         token_budget_texts(&requests[1]),
         initial_token_budget,
         "steady-state context update should not advance the context window"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn token_budget_context_injects_plain_thread_hint_text() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = start_mock_server().await;
+    let rmcp_test_server_bin = stdio_server_bin()?;
+    let test = test_codex()
+        .with_config(move |config| {
+            config.model_context_window = Some(CONFIGURED_CONTEXT_WINDOW);
+            config
+                .features
+                .enable(Feature::TokenBudget)
+                .expect("test config should allow token budget");
+            let mut servers = config.mcp_servers.get().clone();
+            servers.insert(
+                "notes".to_string(),
+                McpServerConfig {
+                    transport: McpServerTransportConfig::Stdio {
+                        command: rmcp_test_server_bin,
+                        args: Vec::new(),
+                        env: None,
+                        env_vars: Vec::new(),
+                        cwd: None,
+                    },
+                    environment_id: "local".to_string(),
+                    enabled: true,
+                    required: false,
+                    supports_parallel_tool_calls: false,
+                    disabled_reason: None,
+                    startup_timeout_sec: Some(Duration::from_secs(10)),
+                    tool_timeout_sec: None,
+                    default_tools_approval_mode: None,
+                    enabled_tools: None,
+                    disabled_tools: None,
+                    scopes: None,
+                    oauth: None,
+                    oauth_resource: None,
+                    tools: HashMap::new(),
+                },
+            );
+            config
+                .mcp_servers
+                .set(servers)
+                .expect("test mcp servers should accept any configuration");
+        })
+        .build(&server)
+        .await?;
+    wait_for_mcp_server(&test.codex, "notes").await?;
+    let responses = mount_sse_sequence(
+        &server,
+        vec![sse(vec![
+            ev_response_created("resp-1"),
+            ev_completed("resp-1"),
+        ])],
+    )
+    .await;
+
+    test.submit_turn("inject the history hint").await?;
+
+    let request = responses.single_request();
+    let thread_id = test.session_configured.thread_id;
+    let token_budgets = token_budget_texts(&request);
+    assert_eq!(token_budgets.len(), 1);
+    let captures = assert_regex_match(
+        &format!(
+            r"^<token_budget>\nThread id {thread_id}\.\nFirst context window id ([0-9a-f-]{{36}})\.\nPrevious context window id none\.\nCurrent context window id ([0-9a-f-]{{36}})\.\nmanual history hint for thread {thread_id}\nunstructured notes/thread_hint fixture result\n</token_budget>$"
+        ),
+        &token_budgets[0],
+    );
+    assert_eq!(
+        captures.get(1).expect("first window id capture").as_str(),
+        captures.get(2).expect("current window id capture").as_str()
+    );
+    assert!(
+        !tool_names(&request)
+            .iter()
+            .any(|name| name == "mcp__notes__thread_hint"),
+        "thread_hint should be hidden from model tool exposure"
     );
 
     Ok(())
@@ -177,7 +261,7 @@ async fn token_budget_remaining_context_emits_on_first_threshold_crossing() -> R
     let thread_id = test.session_configured.thread_id;
     let full_context = token_budget_texts(&requests[0]);
     assert_eq!(full_context.len(), 1);
-    token_budget_window_ids(&full_context[0], thread_id, /*tokens_left*/ 9_500);
+    token_budget_window_ids(&full_context[0], thread_id);
     let full_context = full_context[0].clone();
     let threshold_25 =
         "<token_budget>\nYou have 7000 tokens left in this context window.\n</token_budget>"
@@ -270,7 +354,7 @@ async fn get_context_remaining_returns_token_budget_remaining_fragment() -> Resu
             .to_string();
     let token_budgets = token_budget_texts(&requests[1]);
     assert_eq!(token_budgets.len(), 2);
-    token_budget_window_ids(&token_budgets[0], thread_id, /*tokens_left*/ 9_500);
+    token_budget_window_ids(&token_budgets[0], thread_id);
     assert_eq!(token_budgets[1], remaining_context);
     assert_eq!(
         requests[2].function_call_output_content_and_success(call_id),
@@ -394,22 +478,14 @@ async fn token_budget_context_uses_new_window_after_compaction() -> Result<()> {
     let initial_token_budget = token_budget_texts(&requests[0]);
     assert_eq!(initial_token_budget.len(), 1);
     let (initial_first_window_id, initial_previous_window_id, initial_window_id) =
-        token_budget_window_ids(
-            &initial_token_budget[0],
-            thread_id,
-            EFFECTIVE_CONTEXT_WINDOW,
-        );
+        token_budget_window_ids(&initial_token_budget[0], thread_id);
     let post_compaction_token_budget = token_budget_texts(&requests[2]);
     assert_eq!(post_compaction_token_budget.len(), 1);
     let (
         post_compaction_first_window_id,
         post_compaction_previous_window_id,
         post_compaction_window_id,
-    ) = token_budget_window_ids(
-        &post_compaction_token_budget[0],
-        thread_id,
-        EFFECTIVE_CONTEXT_WINDOW,
-    );
+    ) = token_budget_window_ids(&post_compaction_token_budget[0], thread_id);
     assert_eq!(initial_previous_window_id, None);
     assert_eq!(initial_first_window_id, initial_window_id);
     assert_eq!(post_compaction_first_window_id, initial_first_window_id);
@@ -480,18 +556,12 @@ async fn new_context_tool_starts_new_window_before_follow_up() -> Result<()> {
     let thread_id = test.session_configured.thread_id;
     let initial_token_budget = token_budget_texts(&requests[0]);
     assert_eq!(initial_token_budget.len(), 1);
-    let (initial_first_window_id, _, initial_window_id) = token_budget_window_ids(
-        &initial_token_budget[0],
-        thread_id,
-        EFFECTIVE_CONTEXT_WINDOW,
-    );
+    let (initial_first_window_id, _, initial_window_id) =
+        token_budget_window_ids(&initial_token_budget[0], thread_id);
     let new_window_token_budget = token_budget_texts(&requests[2]);
     assert_eq!(new_window_token_budget.len(), 1);
-    let (new_first_window_id, new_previous_window_id, new_window_id) = token_budget_window_ids(
-        &new_window_token_budget[0],
-        thread_id,
-        EFFECTIVE_CONTEXT_WINDOW,
-    );
+    let (new_first_window_id, new_previous_window_id, new_window_id) =
+        token_budget_window_ids(&new_window_token_budget[0], thread_id);
     assert_eq!(new_first_window_id, initial_first_window_id);
     assert_eq!(
         new_previous_window_id.as_deref(),

--- a/codex-rs/core/tests/suite/token_budget.rs
+++ b/codex-rs/core/tests/suite/token_budget.rs
@@ -33,11 +33,11 @@ use std::time::Duration;
 
 const CONFIGURED_CONTEXT_WINDOW: i64 = 128_000;
 
-fn token_budget_texts(request: &ResponsesRequest) -> Vec<String> {
+fn token_budget_contexts(request: &ResponsesRequest) -> Vec<String> {
     request
         .message_input_texts("developer")
         .into_iter()
-        .filter(|text| text.starts_with("<token_budget>"))
+        .filter(|text| text.starts_with("Thread id "))
         .collect()
 }
 
@@ -47,7 +47,7 @@ fn token_budget_window_ids(
 ) -> (String, Option<String>, String) {
     let captures = assert_regex_match(
         &format!(
-            r"^<token_budget>\nThread id {thread_id}\.\nFirst context window id ([0-9a-f-]{{36}})\.\nPrevious context window id (none|[0-9a-f-]{{36}})\.\nCurrent context window id ([0-9a-f-]{{36}})\.\n</token_budget>$"
+            r"^Thread id {thread_id}\.\nFirst context window id: ([0-9a-f-]{{36}})\nCurrent context window id: ([0-9a-f-]{{36}})(?:\nPrevious context window id: ([0-9a-f-]{{36}}))?$"
         ),
         text,
     );
@@ -56,16 +56,12 @@ fn token_budget_window_ids(
         .expect("first window id capture")
         .as_str()
         .to_string();
-    let previous_window_id = captures
-        .get(2)
-        .expect("previous window id capture")
-        .as_str();
-    let previous_window_id = (previous_window_id != "none").then(|| previous_window_id.to_string());
     let window_id = captures
-        .get(3)
+        .get(2)
         .expect("window id capture")
         .as_str()
         .to_string();
+    let previous_window_id = captures.get(3).map(|capture| capture.as_str().to_string());
     (first_window_id, previous_window_id, window_id)
 }
 
@@ -115,14 +111,14 @@ async fn token_budget_context_is_only_emitted_with_full_context() -> Result<()> 
     assert_eq!(requests.len(), 2);
 
     let thread_id = test.session_configured.thread_id;
-    let initial_token_budget = token_budget_texts(&requests[0]);
+    let initial_token_budget = token_budget_contexts(&requests[0]);
     assert_eq!(initial_token_budget.len(), 1);
     let (first_window_id, previous_window_id, window_id) =
         token_budget_window_ids(&initial_token_budget[0], thread_id);
     assert_eq!(previous_window_id, None);
     assert_eq!(first_window_id, window_id);
     assert_eq!(
-        token_budget_texts(&requests[1]),
+        token_budget_contexts(&requests[1]),
         initial_token_budget,
         "steady-state context update should not advance the context window"
     );
@@ -191,11 +187,11 @@ async fn token_budget_context_injects_plain_thread_hint_text() -> Result<()> {
 
     let request = responses.single_request();
     let thread_id = test.session_configured.thread_id;
-    let token_budgets = token_budget_texts(&request);
+    let token_budgets = token_budget_contexts(&request);
     assert_eq!(token_budgets.len(), 1);
     let captures = assert_regex_match(
         &format!(
-            r"^<token_budget>\nThread id {thread_id}\.\nFirst context window id ([0-9a-f-]{{36}})\.\nPrevious context window id none\.\nCurrent context window id ([0-9a-f-]{{36}})\.\nmanual history hint for thread {thread_id}\nunstructured notes/thread_hint fixture result\n</token_budget>$"
+            r"^Thread id {thread_id}\.\nFirst context window id: ([0-9a-f-]{{36}})\nCurrent context window id: ([0-9a-f-]{{36}})\nmanual history hint for thread {thread_id}\nunstructured notes/thread_hint fixture result$"
         ),
         &token_budgets[0],
     );
@@ -208,92 +204,6 @@ async fn token_budget_context_injects_plain_thread_hint_text() -> Result<()> {
             .iter()
             .any(|name| name == "mcp__notes__thread_hint"),
         "thread_hint should be hidden from model tool exposure"
-    );
-
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn token_budget_remaining_context_emits_on_first_threshold_crossing() -> Result<()> {
-    skip_if_no_network!(Ok(()));
-
-    let server = start_mock_server().await;
-    let responses = mount_sse_sequence(
-        &server,
-        vec![
-            sse(vec![
-                ev_response_created("resp-1"),
-                ev_completed_with_tokens("resp-1", /*total_tokens*/ 2_500),
-            ]),
-            sse(vec![
-                ev_response_created("resp-2"),
-                ev_completed_with_tokens("resp-2", /*total_tokens*/ 3_000),
-            ]),
-            sse(vec![
-                ev_response_created("resp-3"),
-                ev_completed_with_tokens("resp-3", /*total_tokens*/ 5_000),
-            ]),
-            sse(vec![
-                ev_response_created("resp-4"),
-                ev_completed_with_tokens("resp-4", /*total_tokens*/ 8_000),
-            ]),
-            sse(vec![ev_response_created("resp-5"), ev_completed("resp-5")]),
-        ],
-    )
-    .await;
-    let test = test_codex()
-        .with_config(|config| {
-            config.model_context_window = Some(10_000);
-            config
-                .features
-                .enable(Feature::TokenBudget)
-                .expect("test config should allow token budget");
-        })
-        .build(&server)
-        .await?;
-
-    for turn in 1..=5 {
-        test.submit_turn(&format!("turn {turn}")).await?;
-    }
-
-    let requests = responses.requests();
-    assert_eq!(requests.len(), 5);
-
-    let thread_id = test.session_configured.thread_id;
-    let full_context = token_budget_texts(&requests[0]);
-    assert_eq!(full_context.len(), 1);
-    token_budget_window_ids(&full_context[0], thread_id);
-    let full_context = full_context[0].clone();
-    let threshold_25 =
-        "<token_budget>\nYou have 7000 tokens left in this context window.\n</token_budget>"
-            .to_string();
-    let threshold_50 =
-        "<token_budget>\nYou have 4500 tokens left in this context window.\n</token_budget>"
-            .to_string();
-    let threshold_75 =
-        "<token_budget>\nYou have 1500 tokens left in this context window.\n</token_budget>"
-            .to_string();
-
-    assert_eq!(token_budget_texts(&requests[0]), vec![full_context.clone()]);
-    assert_eq!(
-        token_budget_texts(&requests[1]),
-        vec![full_context.clone(), threshold_25.clone()]
-    );
-    assert_eq!(
-        token_budget_texts(&requests[2]),
-        vec![full_context.clone(), threshold_25.clone()]
-    );
-    assert_eq!(
-        token_budget_texts(&requests[3]),
-        vec![
-            full_context.clone(),
-            threshold_25.clone(),
-            threshold_50.clone()
-        ]
-    );
-    assert_eq!(
-        token_budget_texts(&requests[4]),
-        vec![full_context, threshold_25, threshold_50, threshold_75]
     );
 
     Ok(())
@@ -335,17 +245,18 @@ async fn token_budget_reminder_emits_after_crossing_compaction_threshold() -> Re
 
     let requests = responses.requests();
     assert_eq!(requests.len(), 2);
-    let initial_context = token_budget_texts(&requests[0]);
+    let initial_context = token_budget_contexts(&requests[0]);
     assert_eq!(initial_context.len(), 1);
-    let remaining_context =
-        "<token_budget>\nYou have 1500 tokens left in this context window.\n</token_budget>"
-            .to_string();
-    let reminder = "<token_budget>\nYour context window is nearly exhausted (only 1000 tokens remaining) and will be automatically reset for you soon. Once reset, message items in current context window will be cleared in the new window, but notes and history items will be persistent across windows.\n</token_budget>"
-        .to_string();
+    let reminder = "Your context window is nearly exhausted (only 1000 tokens remaining) and will be automatically reset for you soon. Once reset, message items in current context window will be cleared in the new window, but notes and history items will be persistent across windows.";
     assert_eq!(
-        token_budget_texts(&requests[1]),
-        vec![initial_context[0].clone(), remaining_context, reminder]
+        requests[1]
+            .message_input_texts("developer")
+            .into_iter()
+            .filter(|text| text == reminder)
+            .count(),
+        1
     );
+    assert_eq!(token_budget_contexts(&requests[1]), initial_context);
 
     Ok(())
 }
@@ -401,13 +312,10 @@ async fn get_context_remaining_returns_token_budget_remaining_fragment() -> Resu
     );
 
     let thread_id = test.session_configured.thread_id;
-    let remaining_context =
-        "<token_budget>\nYou have 7000 tokens left in this context window.\n</token_budget>"
-            .to_string();
-    let token_budgets = token_budget_texts(&requests[1]);
-    assert_eq!(token_budgets.len(), 2);
+    let remaining_context = "You have 7000 tokens left in this context window.".to_string();
+    let token_budgets = token_budget_contexts(&requests[1]);
+    assert_eq!(token_budgets.len(), 1);
     token_budget_window_ids(&token_budgets[0], thread_id);
-    assert_eq!(token_budgets[1], remaining_context);
     assert_eq!(
         requests[2].function_call_output_content_and_success(call_id),
         Some((Some(remaining_context), None))
@@ -464,14 +372,11 @@ async fn get_context_remaining_returns_unknown_when_window_is_unavailable() -> R
         "get_context_remaining should be exposed when token budget is enabled"
     );
 
-    assert_eq!(token_budget_texts(&requests[0]), Vec::<String>::new());
+    assert_eq!(token_budget_contexts(&requests[0]), Vec::<String>::new());
     assert_eq!(
         requests[1].function_call_output_content_and_success(call_id),
         Some((
-            Some(
-                "<token_budget>\nYou have unknown tokens left in this context window.\n</token_budget>"
-                    .to_string()
-            ),
+            Some("You have unknown tokens left in this context window.".to_string()),
             None,
         ))
     );
@@ -527,11 +432,11 @@ async fn token_budget_context_uses_new_window_after_compaction() -> Result<()> {
     assert_eq!(requests.len(), 3);
 
     let thread_id = test.session_configured.thread_id;
-    let initial_token_budget = token_budget_texts(&requests[0]);
+    let initial_token_budget = token_budget_contexts(&requests[0]);
     assert_eq!(initial_token_budget.len(), 1);
     let (initial_first_window_id, initial_previous_window_id, initial_window_id) =
         token_budget_window_ids(&initial_token_budget[0], thread_id);
-    let post_compaction_token_budget = token_budget_texts(&requests[2]);
+    let post_compaction_token_budget = token_budget_contexts(&requests[2]);
     assert_eq!(post_compaction_token_budget.len(), 1);
     let (
         post_compaction_first_window_id,
@@ -606,11 +511,11 @@ async fn new_context_tool_starts_new_window_before_follow_up() -> Result<()> {
         "new_context should be exposed when token budget is enabled"
     );
     let thread_id = test.session_configured.thread_id;
-    let initial_token_budget = token_budget_texts(&requests[0]);
+    let initial_token_budget = token_budget_contexts(&requests[0]);
     assert_eq!(initial_token_budget.len(), 1);
     let (initial_first_window_id, _, initial_window_id) =
         token_budget_window_ids(&initial_token_budget[0], thread_id);
-    let new_window_token_budget = token_budget_texts(&requests[2]);
+    let new_window_token_budget = token_budget_contexts(&requests[2]);
     assert_eq!(new_window_token_budget.len(), 1);
     let (new_first_window_id, new_previous_window_id, new_window_id) =
         token_budget_window_ids(&new_window_token_budget[0], thread_id);

--- a/codex-rs/core/tests/suite/token_budget.rs
+++ b/codex-rs/core/tests/suite/token_budget.rs
@@ -35,6 +35,35 @@ fn token_budget_texts(request: &ResponsesRequest) -> Vec<String> {
         .collect()
 }
 
+fn token_budget_window_ids(
+    text: &str,
+    thread_id: codex_protocol::ThreadId,
+    tokens_left: i64,
+) -> (String, Option<String>, String) {
+    let captures = assert_regex_match(
+        &format!(
+            r"^<token_budget>\nThread id {thread_id}\.\nFirst context window id ([0-9a-f-]{{36}})\.\nPrevious context window id (none|[0-9a-f-]{{36}})\.\nCurrent context window id ([0-9a-f-]{{36}})\.\nYou have {tokens_left} tokens left in this context window\.\n</token_budget>$"
+        ),
+        text,
+    );
+    let first_window_id = captures
+        .get(1)
+        .expect("first window id capture")
+        .as_str()
+        .to_string();
+    let previous_window_id = captures
+        .get(2)
+        .expect("previous window id capture")
+        .as_str();
+    let previous_window_id = (previous_window_id != "none").then(|| previous_window_id.to_string());
+    let window_id = captures
+        .get(3)
+        .expect("window id capture")
+        .as_str()
+        .to_string();
+    (first_window_id, previous_window_id, window_id)
+}
+
 fn tool_names(request: &ResponsesRequest) -> Vec<String> {
     request
         .body_json()
@@ -83,12 +112,13 @@ async fn token_budget_context_is_only_emitted_with_full_context() -> Result<()> 
     let thread_id = test.session_configured.thread_id;
     let initial_token_budget = token_budget_texts(&requests[0]);
     assert_eq!(initial_token_budget.len(), 1);
-    assert_regex_match(
-        &format!(
-            r"^<token_budget>\nThread id {thread_id}\.\nCurrent context window id [0-9a-f-]{{36}}\.\nYou have {EFFECTIVE_CONTEXT_WINDOW} tokens left in this context window\.\n</token_budget>$"
-        ),
+    let (first_window_id, previous_window_id, window_id) = token_budget_window_ids(
         &initial_token_budget[0],
+        thread_id,
+        EFFECTIVE_CONTEXT_WINDOW,
     );
+    assert_eq!(previous_window_id, None);
+    assert_eq!(first_window_id, window_id);
     assert_eq!(
         token_budget_texts(&requests[1]),
         initial_token_budget,
@@ -147,12 +177,7 @@ async fn token_budget_remaining_context_emits_on_first_threshold_crossing() -> R
     let thread_id = test.session_configured.thread_id;
     let full_context = token_budget_texts(&requests[0]);
     assert_eq!(full_context.len(), 1);
-    assert_regex_match(
-        &format!(
-            r"^<token_budget>\nThread id {thread_id}\.\nCurrent context window id [0-9a-f-]{{36}}\.\nYou have 9500 tokens left in this context window\.\n</token_budget>$"
-        ),
-        &full_context[0],
-    );
+    token_budget_window_ids(&full_context[0], thread_id, /*tokens_left*/ 9_500);
     let full_context = full_context[0].clone();
     let threshold_25 =
         "<token_budget>\nYou have 7000 tokens left in this context window.\n</token_budget>"
@@ -245,12 +270,7 @@ async fn get_context_remaining_returns_token_budget_remaining_fragment() -> Resu
             .to_string();
     let token_budgets = token_budget_texts(&requests[1]);
     assert_eq!(token_budgets.len(), 2);
-    assert_regex_match(
-        &format!(
-            r"^<token_budget>\nThread id {thread_id}\.\nCurrent context window id [0-9a-f-]{{36}}\.\nYou have 9500 tokens left in this context window\.\n</token_budget>$"
-        ),
-        &token_budgets[0],
-    );
+    token_budget_window_ids(&token_budgets[0], thread_id, /*tokens_left*/ 9_500);
     assert_eq!(token_budgets[1], remaining_context);
     assert_eq!(
         requests[2].function_call_output_content_and_success(call_id),
@@ -373,28 +393,30 @@ async fn token_budget_context_uses_new_window_after_compaction() -> Result<()> {
     let thread_id = test.session_configured.thread_id;
     let initial_token_budget = token_budget_texts(&requests[0]);
     assert_eq!(initial_token_budget.len(), 1);
-    let initial_window_id = assert_regex_match(
-        &format!(
-            r"^<token_budget>\nThread id {thread_id}\.\nCurrent context window id ([0-9a-f-]{{36}})\.\nYou have {EFFECTIVE_CONTEXT_WINDOW} tokens left in this context window\.\n</token_budget>$"
-        ),
-        &initial_token_budget[0],
-    )
-    .get(1)
-    .expect("window id capture")
-    .as_str()
-    .to_string();
+    let (initial_first_window_id, initial_previous_window_id, initial_window_id) =
+        token_budget_window_ids(
+            &initial_token_budget[0],
+            thread_id,
+            EFFECTIVE_CONTEXT_WINDOW,
+        );
     let post_compaction_token_budget = token_budget_texts(&requests[2]);
     assert_eq!(post_compaction_token_budget.len(), 1);
-    let post_compaction_window_id = assert_regex_match(
-        &format!(
-            r"^<token_budget>\nThread id {thread_id}\.\nCurrent context window id ([0-9a-f-]{{36}})\.\nYou have {EFFECTIVE_CONTEXT_WINDOW} tokens left in this context window\.\n</token_budget>$"
-        ),
+    let (
+        post_compaction_first_window_id,
+        post_compaction_previous_window_id,
+        post_compaction_window_id,
+    ) = token_budget_window_ids(
         &post_compaction_token_budget[0],
-    )
-    .get(1)
-    .expect("window id capture")
-    .as_str()
-    .to_string();
+        thread_id,
+        EFFECTIVE_CONTEXT_WINDOW,
+    );
+    assert_eq!(initial_previous_window_id, None);
+    assert_eq!(initial_first_window_id, initial_window_id);
+    assert_eq!(post_compaction_first_window_id, initial_first_window_id);
+    assert_eq!(
+        post_compaction_previous_window_id.as_deref(),
+        Some(initial_window_id.as_str())
+    );
     assert_ne!(post_compaction_window_id, initial_window_id);
 
     Ok(())
@@ -458,29 +480,24 @@ async fn new_context_tool_starts_new_window_before_follow_up() -> Result<()> {
     let thread_id = test.session_configured.thread_id;
     let initial_token_budget = token_budget_texts(&requests[0]);
     assert_eq!(initial_token_budget.len(), 1);
-    let initial_window_id = assert_regex_match(
-        &format!(
-            r"^<token_budget>\nThread id {thread_id}\.\nCurrent context window id ([0-9a-f-]{{36}})\.\nYou have {EFFECTIVE_CONTEXT_WINDOW} tokens left in this context window\.\n</token_budget>$"
-        ),
+    let (initial_first_window_id, _, initial_window_id) = token_budget_window_ids(
         &initial_token_budget[0],
-    )
-    .get(1)
-    .expect("window id capture")
-    .as_str()
-    .to_string();
+        thread_id,
+        EFFECTIVE_CONTEXT_WINDOW,
+    );
     let new_window_token_budget = token_budget_texts(&requests[2]);
     assert_eq!(new_window_token_budget.len(), 1);
-    let window_id = assert_regex_match(
-        &format!(
-            r"^<token_budget>\nThread id {thread_id}\.\nCurrent context window id ([0-9a-f-]{{36}})\.\nYou have {EFFECTIVE_CONTEXT_WINDOW} tokens left in this context window\.\n</token_budget>$"
-        ),
+    let (new_first_window_id, new_previous_window_id, new_window_id) = token_budget_window_ids(
         &new_window_token_budget[0],
-    )
-    .get(1)
-    .expect("window id capture")
-    .as_str()
-    .to_string();
-    assert_ne!(window_id, initial_window_id);
+        thread_id,
+        EFFECTIVE_CONTEXT_WINDOW,
+    );
+    assert_eq!(new_first_window_id, initial_first_window_id);
+    assert_eq!(
+        new_previous_window_id.as_deref(),
+        Some(initial_window_id.as_str())
+    );
+    assert_ne!(new_window_id, initial_window_id);
     assert!(
         !requests[2].body_contains_text("request new context window"),
         "new_context should drop the prior window history before continuing the turn"
@@ -496,7 +513,8 @@ async fn new_context_tool_starts_new_window_before_follow_up() -> Result<()> {
     );
     let snapshot = snapshot
         .replace(&thread_id.to_string(), "<THREAD_ID>")
-        .replace(&window_id, "<UUID>");
+        .replace(&new_first_window_id, "<FIRST_WINDOW_ID>")
+        .replace(&new_window_id, "<WINDOW_ID>");
     insta::assert_snapshot!(
         "token_budget_new_context_window_tool_full_context",
         snapshot

--- a/codex-rs/core/tests/suite/token_budget.rs
+++ b/codex-rs/core/tests/suite/token_budget.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use codex_config::types::McpServerConfig;
 use codex_config::types::McpServerTransportConfig;
+use codex_core::config::TokenBudgetConfig;
 use codex_features::Feature;
 use codex_model_provider_info::built_in_model_providers;
 use codex_protocol::protocol::EventMsg;
@@ -293,6 +294,57 @@ async fn token_budget_remaining_context_emits_on_first_threshold_crossing() -> R
     assert_eq!(
         token_budget_texts(&requests[4]),
         vec![full_context, threshold_25, threshold_50, threshold_75]
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn token_budget_reminder_emits_after_crossing_compaction_threshold() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = start_mock_server().await;
+    let responses = mount_sse_sequence(
+        &server,
+        vec![
+            sse(vec![
+                ev_response_created("resp-1"),
+                ev_completed_with_tokens("resp-1", /*total_tokens*/ 8_000),
+            ]),
+            sse(vec![ev_response_created("resp-2"), ev_completed("resp-2")]),
+        ],
+    )
+    .await;
+    let test = test_codex()
+        .with_config(|config| {
+            config.model_context_window = Some(10_000);
+            config.token_budget = Some(TokenBudgetConfig {
+                reminder_threshold_tokens: Some(2_000),
+                ..TokenBudgetConfig::default()
+            });
+            config
+                .features
+                .enable(Feature::TokenBudget)
+                .expect("test config should allow token budget");
+        })
+        .build(&server)
+        .await?;
+
+    test.submit_turn("cross threshold").await?;
+    test.submit_turn("observe reminder").await?;
+
+    let requests = responses.requests();
+    assert_eq!(requests.len(), 2);
+    let initial_context = token_budget_texts(&requests[0]);
+    assert_eq!(initial_context.len(), 1);
+    let remaining_context =
+        "<token_budget>\nYou have 1500 tokens left in this context window.\n</token_budget>"
+            .to_string();
+    let reminder = "<token_budget>\nYour context window is nearly exhausted (only 1000 tokens remaining) and will be automatically reset for you soon. Once reset, message items in current context window will be cleared in the new window, but notes and history items will be persistent across windows.\n</token_budget>"
+        .to_string();
+    assert_eq!(
+        token_budget_texts(&requests[1]),
+        vec![initial_context[0].clone(), remaining_context, reminder]
     );
 
     Ok(())

--- a/codex-rs/features/src/feature_configs.rs
+++ b/codex-rs/features/src/feature_configs.rs
@@ -73,6 +73,32 @@ impl FeatureConfig for MultiAgentV2ConfigToml {
     }
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, Eq, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct TokenBudgetConfigToml {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enabled: Option<bool>,
+    /// Number of tokens remaining before auto-compaction when the wrap-up reminder is emitted.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schemars(range(min = 1))]
+    pub reminder_threshold_tokens: Option<i64>,
+    /// Reminder template. `{n_remaining}` is replaced with the tokens remaining before
+    /// auto-compaction.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schemars(length(min = 1, max = 1000))]
+    pub reminder_message_template: Option<String>,
+}
+
+impl FeatureConfig for TokenBudgetConfigToml {
+    fn enabled(&self) -> Option<bool> {
+        self.enabled
+    }
+
+    fn set_enabled(&mut self, enabled: bool) {
+        self.enabled = Some(enabled);
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct RolloutBudgetConfigToml {

--- a/codex-rs/features/src/lib.rs
+++ b/codex-rs/features/src/lib.rs
@@ -26,6 +26,7 @@ pub use feature_configs::NetworkProxyModeToml;
 pub use feature_configs::NetworkProxyUnixSocketPermissionToml;
 use feature_configs::RemovedAppsMcpPathOverrideConfigToml;
 pub use feature_configs::RolloutBudgetConfigToml;
+pub use feature_configs::TokenBudgetConfigToml;
 use legacy::LegacyFeatureToggles;
 pub use legacy::legacy_feature_keys;
 
@@ -632,6 +633,8 @@ pub struct FeaturesToml {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub multi_agent_v2: Option<FeatureToml<MultiAgentV2ConfigToml>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub token_budget: Option<FeatureToml<TokenBudgetConfigToml>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub rollout_budget: Option<FeatureToml<RolloutBudgetConfigToml>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub current_time_reminder: Option<FeatureToml<CurrentTimeReminderConfigToml>>,
@@ -667,6 +670,9 @@ impl FeaturesToml {
         if let Some(enabled) = self.multi_agent_v2.as_ref().and_then(FeatureToml::enabled) {
             entries.insert(Feature::MultiAgentV2.key().to_string(), enabled);
         }
+        if let Some(enabled) = self.token_budget.as_ref().and_then(FeatureToml::enabled) {
+            entries.insert(Feature::TokenBudget.key().to_string(), enabled);
+        }
         if let Some(enabled) = self.rollout_budget.as_ref().and_then(FeatureToml::enabled) {
             entries.insert(Feature::RolloutBudget.key().to_string(), enabled);
         }
@@ -688,6 +694,7 @@ impl FeaturesToml {
         let Self {
             code_mode,
             multi_agent_v2,
+            token_budget,
             rollout_budget,
             current_time_reminder,
             removed_apps_mcp_path_override: _,
@@ -703,6 +710,8 @@ impl FeaturesToml {
                 materialize_resolved_feature_enabled(code_mode, enabled);
             } else if spec.id == Feature::MultiAgentV2 {
                 materialize_resolved_feature_enabled(multi_agent_v2, enabled);
+            } else if spec.id == Feature::TokenBudget {
+                materialize_resolved_feature_enabled(token_budget, enabled);
             } else if spec.id == Feature::RolloutBudget {
                 materialize_resolved_feature_enabled(rollout_budget, enabled);
             } else if spec.id == Feature::CurrentTimeReminder {

--- a/codex-rs/protocol/src/compacted_item.rs
+++ b/codex-rs/protocol/src/compacted_item.rs
@@ -23,6 +23,8 @@ impl<'de> Deserialize<'de> for CompactedItem {
             message: serialized.message,
             replacement_history: serialized.replacement_history,
             window_number,
+            first_window_id: serialized.first_window_id,
+            previous_window_id: serialized.previous_window_id,
             window_id,
         })
     }
@@ -35,6 +37,10 @@ struct SerializedCompactedItem {
     replacement_history: Option<Vec<ResponseItem>>,
     #[serde(default)]
     window_number: Option<u64>,
+    #[serde(default)]
+    first_window_id: Option<String>,
+    #[serde(default)]
+    previous_window_id: Option<String>,
     #[serde(default)]
     window_id: Option<SerializedWindowId>,
 }
@@ -59,6 +65,8 @@ mod tests {
             message: "summary".to_string(),
             replacement_history: None,
             window_number: Some(3),
+            first_window_id: Some("019b3f6e-0000-7000-8000-000000000001".to_string()),
+            previous_window_id: Some("019b3f6e-0000-7000-8000-000000000002".to_string()),
             window_id: Some("019b3f6e-7a10-7cc3-8b6e-1d09e2f7a001".to_string()),
         };
 
@@ -67,6 +75,8 @@ mod tests {
             json!({
                 "message": "summary",
                 "window_number": 3,
+                "first_window_id": "019b3f6e-0000-7000-8000-000000000001",
+                "previous_window_id": "019b3f6e-0000-7000-8000-000000000002",
                 "window_id": "019b3f6e-7a10-7cc3-8b6e-1d09e2f7a001",
             })
         );
@@ -86,6 +96,8 @@ mod tests {
                 message: "summary".to_string(),
                 replacement_history: None,
                 window_number: Some(3),
+                first_window_id: None,
+                previous_window_id: None,
                 window_id: None,
             }
         );

--- a/codex-rs/protocol/src/protocol.rs
+++ b/codex-rs/protocol/src/protocol.rs
@@ -2996,6 +2996,12 @@ pub struct CompactedItem {
     /// Monotonic position of this context window within the thread.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub window_number: Option<u64>,
+    /// UUIDv7 identity of the first context window in this thread's window chain.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub first_window_id: Option<String>,
+    /// UUIDv7 identity of the context window immediately before this one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub previous_window_id: Option<String>,
     /// UUIDv7 identity of this context window.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub window_id: Option<String>,

--- a/codex-rs/rmcp-client/src/bin/test_stdio_server.rs
+++ b/codex-rs/rmcp-client/src/bin/test_stdio_server.rs
@@ -19,6 +19,7 @@ use rmcp::model::JsonObject;
 use rmcp::model::ListResourceTemplatesResult;
 use rmcp::model::ListResourcesResult;
 use rmcp::model::ListToolsResult;
+use rmcp::model::Meta;
 use rmcp::model::PaginatedRequestParams;
 use rmcp::model::RawResource;
 use rmcp::model::RawResourceTemplate;
@@ -70,9 +71,27 @@ impl TestToolServer {
         );
         sandbox_meta_tool.annotations = Some(ToolAnnotations::new().read_only(true));
 
+        #[expect(clippy::expect_used)]
+        let thread_hint_schema: JsonObject = serde_json::from_value(json!({
+            "type": "object",
+            "properties": {},
+            "additionalProperties": false
+        }))
+        .expect("thread_hint tool schema should deserialize");
+        let mut thread_hint_tool = Tool::new(
+            Cow::Borrowed("thread_hint"),
+            Cow::Borrowed("Return an unstructured history hint for a thread."),
+            Arc::new(thread_hint_schema),
+        );
+        thread_hint_tool.annotations = Some(ToolAnnotations::new().read_only(true));
+        let mut thread_hint_meta = Meta::new();
+        thread_hint_meta.insert("ui".to_string(), json!({ "visibility": [] }));
+        thread_hint_tool.meta = Some(thread_hint_meta);
+
         let tools = vec![
             Self::echo_tool(),
             Self::echo_dash_tool(),
+            thread_hint_tool,
             Self::client_capabilities_tool(),
             Self::cwd_tool(),
             Self::sync_tool(),
@@ -536,6 +555,22 @@ impl ServerHandler for TestToolServer {
                     .map(|path| path.to_string_lossy().into_owned())
                     .map_err(|err| McpError::internal_error(err.to_string(), None))?;
                 Ok(Self::structured_result(json!({ "cwd": cwd })))
+            }
+            "thread_hint" => {
+                let thread_id = context
+                    .meta
+                    .0
+                    .get("threadId")
+                    .and_then(serde_json::Value::as_str)
+                    .ok_or_else(|| {
+                        McpError::invalid_params("missing threadId metadata".to_string(), None)
+                    })?;
+                Ok(CallToolResult::success(vec![
+                    rmcp::model::Content::text(format!(
+                        "manual history hint for thread {thread_id}"
+                    )),
+                    rmcp::model::Content::text("unstructured notes/thread_hint fixture result"),
+                ]))
             }
             "echo" | "echo-tool" => {
                 let args: EchoArgs = match request.arguments {

--- a/codex-rs/rollout/src/metadata_tests.rs
+++ b/codex-rs/rollout/src/metadata_tests.rs
@@ -155,6 +155,8 @@ fn builder_from_items_falls_back_to_filename() {
         message: "noop".to_string(),
         replacement_history: None,
         window_number: None,
+        first_window_id: None,
+        previous_window_id: None,
         window_id: None,
     })];
 

--- a/codex-rs/thread-manager-sample/src/main.rs
+++ b/codex-rs/thread-manager-sample/src/main.rs
@@ -280,6 +280,7 @@ fn new_config(model: Option<String>, arg0_paths: Arg0DispatchPaths) -> anyhow::R
         background_terminal_max_timeout: 300_000,
         ghost_snapshot: GhostSnapshotConfig::default(),
         multi_agent_v2: MultiAgentV2Config::default(),
+        token_budget: None,
         rollout_budget: None,
         current_time_reminder: None,
         features: Default::default(),

--- a/codex-rs/thread-store/src/thread_metadata_sync.rs
+++ b/codex-rs/thread-store/src/thread_metadata_sync.rs
@@ -484,6 +484,8 @@ mod tests {
             message: "compacted".to_string(),
             replacement_history: None,
             window_number: None,
+            first_window_id: None,
+            previous_window_id: None,
             window_id: None,
         });
 


### PR DESCRIPTION
Daily upstream sync. Merges openai/codex upstream/main into feat/claude-compat with a normal merge commit.

Verification:
- cargo check --workspace --offline
- cargo test --offline -p codex-core-skills -p codex-hooks
- cargo test --offline -p codex-cli --test version
- cargo build --offline --release -p codex-cli --bin codex

Note: verification used repo-pinned rustc 1.95.0. The older 1.93.0 setup fails dependency MSRV before compilation because sqlx 0.9.0 requires rustc 1.94.0+.

Conflict-resolution log: zero conflicts.