### PR TITLE
feat(config): map Claude capability aliases

### DIFF
--- a/codex-rs/core/src/config/agent_roles.rs
+++ b/codex-rs/core/src/config/agent_roles.rs
@@ -16,6 +16,7 @@ use std::path::PathBuf;
 use toml::Value as TomlValue;
 
 const GPT_5_6_LUNA_MODEL: &str = "gpt-5.6-luna";
+const GPT_5_6_SOL_MODEL: &str = "gpt-5.6-sol";
 
 #[derive(Clone, Copy)]
 struct ClaudeAgentModelMapping {
@@ -753,17 +754,24 @@ fn claude_agent_model_reasoning_effort(model: &str) -> Option<&'static str> {
 
 fn claude_agent_model_mapping(model: &str) -> Option<ClaudeAgentModelMapping> {
     let lower = model.to_ascii_lowercase();
-    if lower.contains("opus") {
+    let family = match lower.as_str() {
+        "opus" | "sonnet" | "haiku" => lower.as_str(),
+        _ => lower
+            .strip_prefix("claude-")?
+            .split('-')
+            .find(|segment| matches!(*segment, "opus" | "sonnet" | "haiku"))?,
+    };
+    if family == "opus" {
         Some(ClaudeAgentModelMapping {
-            model: GPT_5_6_LUNA_MODEL,
-            reasoning_effort: "max",
+            model: GPT_5_6_SOL_MODEL,
+            reasoning_effort: "high",
         })
-    } else if lower.contains("sonnet") {
+    } else if family == "sonnet" {
         Some(ClaudeAgentModelMapping {
             model: GPT_5_6_LUNA_MODEL,
             reasoning_effort: "high",
         })
-    } else if lower.contains("haiku") {
+    } else if family == "haiku" {
         Some(ClaudeAgentModelMapping {
             model: GPT_5_6_LUNA_MODEL,
             reasoning_effort: "medium",

--- a/codex-rs/core/src/config/agent_roles_tests.rs
+++ b/codex-rs/core/src/config/agent_roles_tests.rs
@@ -1,4 +1,5 @@
 use super::GPT_5_6_LUNA_MODEL;
+use super::GPT_5_6_SOL_MODEL;
 use super::claude_agent_model_reasoning_effort;
 use super::normalize_claude_agent_model_name;
 use super::parse_agent_role_file_contents;
@@ -7,14 +8,23 @@ use std::path::Path;
 use toml::Value as TomlValue;
 
 #[test]
-fn claude_agent_model_aliases_map_to_luna_with_role_effort() {
+fn claude_agent_model_aliases_map_to_capability_tiers() {
+    assert_eq!(normalize_claude_agent_model_name("opus"), GPT_5_6_SOL_MODEL);
+    assert_eq!(claude_agent_model_reasoning_effort("opus"), Some("high"));
     assert_eq!(
-        normalize_claude_agent_model_name("opus"),
-        GPT_5_6_LUNA_MODEL
+        normalize_claude_agent_model_name("claude-opus-5"),
+        GPT_5_6_SOL_MODEL
     );
-    assert_eq!(claude_agent_model_reasoning_effort("opus"), Some("max"));
+    assert_eq!(
+        normalize_claude_agent_model_name("claude-3-opus-20240229"),
+        GPT_5_6_SOL_MODEL
+    );
     assert_eq!(
         normalize_claude_agent_model_name("claude-sonnet-4-20250514"),
+        GPT_5_6_LUNA_MODEL
+    );
+    assert_eq!(
+        normalize_claude_agent_model_name("claude-3-5-sonnet-20241022"),
         GPT_5_6_LUNA_MODEL
     );
     assert_eq!(
@@ -29,6 +39,19 @@ fn claude_agent_model_aliases_map_to_luna_with_role_effort() {
         claude_agent_model_reasoning_effort("claude-haiku-4-5"),
         Some("medium")
     );
+    assert_eq!(
+        normalize_claude_agent_model_name("custom-opus-reviewer"),
+        "custom-opus-reviewer"
+    );
+    assert_eq!(
+        claude_agent_model_reasoning_effort("custom-opus-reviewer"),
+        None
+    );
+    assert_eq!(
+        normalize_claude_agent_model_name("opus-local"),
+        "opus-local"
+    );
+    assert_eq!(claude_agent_model_reasoning_effort("opus-local"), None);
 }
 
 #[test]
@@ -52,5 +75,27 @@ model_reasoning_effort = "high"
 
     assert_eq!(parsed.role_name, "reviewer");
     assert_eq!(parsed.description.as_deref(), Some("Review code"));
+    assert_eq!(parsed.config, expected);
+}
+
+#[test]
+fn claude_agent_markdown_import_maps_opus_to_sol_high() {
+    let parsed = parse_agent_role_file_contents(
+        "---\nname: reviewer\ndescription: Review code\nmodel: opus\n---\nReview carefully.\n",
+        Path::new("reviewer.md"),
+        Path::new("."),
+        None,
+    )
+    .expect("parse Claude agent role");
+
+    let expected: TomlValue = toml::from_str(
+        r#"
+developer_instructions = "Review carefully."
+model = "gpt-5.6-sol"
+model_reasoning_effort = "high"
+"#,
+    )
+    .expect("parse expected config");
+
     assert_eq!(parsed.config, expected);
 }


### PR DESCRIPTION
## Summary

- map imported Claude Opus aliases to `gpt-5.6-sol` with high reasoning
- keep Sonnet on Luna/high and Haiku on Luna/medium
- restrict matching to exact aliases or family tokens in concrete `claude-*` IDs

## Verification

- `cargo +1.95.0 check --manifest-path codex-rs/Cargo.toml -p codex-core --lib`
- pinned nightly `rustfmt` on both changed files
- `git diff --check`
- independent `gpt-5.6-sol`/high review: PASS

The focused test target cannot compile on the current integration base because unrelated existing test code references missing symbols (`Op::UserInput`, `fs`, `tempdir`, and others). The production library check passes.